### PR TITLE
Allow jenkins to choose the home directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,9 @@
 # Parameters:
-# config_hash = {} (Default)
+# config_hash = { 'JENKINS_HOME' => { '/var/lib/jenkins' } } (Default)
 # Hash with config options to set in sysconfig/jenkins defaults/jenkins
+#
+# jenkins_home = '/var/lib/jenkins'
+#   Home directory of jenkins user.
 #
 # Example use
 #
@@ -11,9 +14,10 @@
 # }
 #
 class jenkins::config(
-  $config_hash = {},
+  $config_hash = { },
+  $jenkins_home = '/var/lib/jenkins',
 ) {
   Class['Jenkins::Package']->Class['Jenkins::Config']
   create_resources( 'jenkins::sysconfig', $config_hash )
+  create_resources( 'jenkins::sysconfig', {  'JENKINS_HOME' => { 'value' => "$jenkins_home" } } )
 }
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,9 @@
 # config_hash = undef (Default)
 # Hash with config options to set in sysconfig/jenkins defaults/jenkins
 #
+# jenkins_home = '/var/lib/jenkins'
+#   Home directory of jenkins user.
+#
 # Example use
 #
 # class{ 'jenkins::config':
@@ -58,6 +61,7 @@ class jenkins(
   $configure_firewall = true,
   $proxy_host = undef,
   $proxy_port = undef,
+  $jenkins_home = '/var/lib/jenkins',
 ) {
   anchor {'jenkins::begin':}
   anchor {'jenkins::end':}
@@ -72,7 +76,8 @@ class jenkins(
   }
 
   class { 'jenkins::config':
-      config_hash => $config_hash,
+      config_hash  => $config_hash,
+      jenkins_home => $jenkins_home,
   }
 
   class { 'jenkins::plugins':

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -3,8 +3,8 @@
 #
 define jenkins::plugin($version=0) {
   $plugin            = "${name}.hpi"
-  $plugin_dir        = '/var/lib/jenkins/plugins'
-  $plugin_parent_dir = '/var/lib/jenkins'
+  $plugin_dir        = "${jenkins::jenkins_home}/plugins"
+  $plugin_parent_dir = "${jenkins::jenkins_home}"
 
   if ($version != 0) {
     $base_url = "http://updates.jenkins-ci.org/download/plugins/${name}/${version}/"


### PR DESCRIPTION
Hi

I am  working with servers where the admin wants jenkins to be installed into /srv/jenkins, resp. /home/jenkins.

This patch allows me to specify a JENKINS_HOME.

Thanks in advance

Best regards