### PR TITLE
Parameterize jenkins plugin repository and add support for core plugins

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,19 +68,35 @@
 #   - use puppetlabs-java module to install the correct version of a JDK.
 #   - Jenkins requires a JRE
 #
+#
+# plugin_repository_maven_style 
+#   True if the repository provides artifacts in the form
+#
+#     <base_url>/<plugin_name>/<plugin_version>/<plugin_name>-<plugin_version>.hpi
+#
+#   When false we assume the repository provides a link to the latest version of a plugin.
+#
+#
+# default_plugin_group_id
+#   Group id to use when a plugin does not define it explicitly.
+#   This is only relevant when $plugin_repository_maven_style is set.
+#
 class jenkins(
-  $version            = $jenkins::params::version,
-  $lts                = $jenkins::params::lts,
-  $repo               = $jenkins::params::repo,
-  $service_enable     = $jenkins::params::service_enable,
-  $service_ensure     = $jenkins::params::service_ensure,
-  $config_hash        = {},
-  $plugin_hash        = {},
-  $configure_firewall = undef,
-  $install_java       = $jenkins::params::install_java,
-  $proxy_host         = undef,
-  $proxy_port         = undef,
-  $cli                = undef,
+  $version                       = $jenkins::params::version,
+  $lts                           = $jenkins::params::lts,
+  $repo                          = $jenkins::params::repo,
+  $service_enable                = $jenkins::params::service_enable,
+  $service_ensure                = $jenkins::params::service_ensure,
+  $config_hash                   = {},
+  $plugin_hash                   = {},
+  $plugin_repository_base_url    = $jenkins::params::plugin_repository_base_url,
+  $plugin_repository_maven_style = $jenkins::params::plugin_repository_maven_style,
+  $default_plugin_group_id       = $jenkins::params::default_plugin_group_id,
+  $configure_firewall            = undef,
+  $install_java                  = $jenkins::params::install_java,
+  $proxy_host                    = undef,
+  $proxy_port                    = undef,
+  $cli                           = undef,
 ) inherits jenkins::params {
 
   validate_bool($lts, $install_java, $repo)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,13 +2,17 @@
 #
 #
 class jenkins::params {
-  $version            = 'installed'
-  $lts                = false
-  $repo               = true
-  $service_enable     = true
-  $service_ensure     = 'running'
-  $install_java       = true
-  $swarm_version      = '1.9'
+  $version                       = 'installed'
+  $lts                           = false
+  $repo                          = true
+  $service_enable                = true
+  $service_ensure                = 'running'
+  $install_java                  = true
+  $swarm_version                 = '1.9'
+
+  $plugin_repository_base_url    = 'http://updates.jenkins-ci.org/download/plugins/'
+  $plugin_repository_maven_style = false
+  $default_plugin_group_id       = 'org.jenkins-ci.plugins'
 }
 
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -6,11 +6,21 @@
 #   Content of the config file for this plugin. It is up to the caller to
 #   create this content from a template or any other mean.
 #
+# group_id = undef
+#   allow overriding the default $jenkins::default_plugin_group_id
+#
+# core = false
+#   Set to true for a core plugin (aka pinned plugin: https://wiki.jenkins-ci.org/display/JENKINS/Pinned+Plugins).
+#   This is needed if you want to set a different version of a core plugin from the version hardcoded
+#   within jenkins.
+#
 define jenkins::plugin(
   $version=0,
   $manage_config   = false,
   $config_filename = undef,
   $config_content  = undef,
+  $group_id        = undef,
+  $core            = undef,
 ) {
 
   $plugin            = "${name}.hpi"
@@ -19,13 +29,28 @@ define jenkins::plugin(
   validate_bool ($manage_config)
 
   if ($version != 0) {
-    $base_url = "http://updates.jenkins-ci.org/download/plugins/${name}/${version}/"
+    if ($jenkins::plugin_repository_maven_style) {
+      if ($group_id) {
+        $id = $group_id
+      } else {
+        $id = $jenkins::default_plugin_group_id
+      }
+      $group_id_path = regsubst( $id, '\.', '/', 'G' )
+      $hpi_url = "${jenkins::plugin_repository_base_url}${group_id_path}/${name}/${version}/${name}-${version}.hpi"
+    } else {
+      $hpi_url = "${jenkins::plugin_repository_base_url}${name}/${version}/${name}.hpi"
+    }
     $search   = "${name} ${version}(,|$)"
   }
   else {
-    $base_url = 'http://updates.jenkins-ci.org/latest/'
-    $search   = "${name} "
+    if ($jenkins::plugin_repository_maven_style) {
+      fail('When using maven style plugin repository, plugin versions must be specified')
+    } else {
+      $hpi_url = "${jenkins::plugin_repository_base_url}latest/${name}.hpi"
+      $search   = "${name} "
+    }
   }
+
 
   if (!defined(File[$plugin_dir])) {
     file { [$plugin_parent_dir, $plugin_dir]:
@@ -70,13 +95,26 @@ define jenkins::plugin(
     }
 
     exec { "download-${name}" :
-      command    => "rm -rf ${name} ${name}.* && wget --no-check-certificate ${base_url}${plugin}",
+      command    => "rm -rf ${name} ${name}.* && wget --no-check-certificate ${hpi_url} -O ${name}.hpi",
       cwd        => $plugin_dir,
       require    => [File[$plugin_dir], Package['wget']],
       path       => ['/usr/bin', '/usr/sbin', '/bin'],
     }
 
-    file { "${plugin_dir}/${plugin}" :
+    if ($core) {
+      # core plugins need to be pinned in order to update
+      # see : https://wiki.jenkins-ci.org/display/JENKINS/Plugin+tutorial#Plugintutorial-Deployingacustombuildofacoreplugin
+      file { "${plugin_dir}/${name}.hpi.pinned":
+        ensure  => 'present',
+        content => '',
+        owner   => 'jenkins',
+        mode    => '0644',
+        # note: the download command cleans ${name}.* and therefore must be executed before this
+        require => [Exec["download-${name}"],File["${plugin_dir}/${name}.hpi"]],
+      }
+    }
+
+    file { "${plugin_dir}/${name}.hpi" :
       require => Exec["download-${name}"],
       owner   => 'jenkins',
       mode    => '0644',


### PR DESCRIPTION
This is useful when you want jenkins to download plugins from an enterprise repository.
Repository base url can be redefined and accept a maven style layout. When necessary plugins can use a different groupId:

    dynamicparameter : {
        version: "0.2.0",
        group_id: "com.seitenbau.jenkins.plugins"
    }

As for the core plugin support this should fix https://github.com/jenkinsci/puppet-jenkins/issues/118
Simply set core to the core plugins that you want to upgrade:

    matrix-auth : { 
        version: "1.2",
        core: true
    }