### PR TITLE
Ensure plugin download exec is idempotent

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -74,6 +74,7 @@ define jenkins::plugin(
       cwd        => $plugin_dir,
       require    => [File[$plugin_dir], Package['wget']],
       path       => ['/usr/bin', '/usr/sbin', '/bin'],
+      unless     => "test -f ${plugin}",
     }
 
     file { "${plugin_dir}/${plugin}" :

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -74,7 +74,7 @@ define jenkins::plugin(
       cwd        => $plugin_dir,
       require    => [File[$plugin_dir], Package['wget']],
       path       => ['/usr/bin', '/usr/sbin', '/bin'],
-      creates    => $plugin,
+      creates    => "${plugin_dir}/${plugin}",
     }
 
     file { "${plugin_dir}/${plugin}" :

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -74,7 +74,7 @@ define jenkins::plugin(
       cwd        => $plugin_dir,
       require    => [File[$plugin_dir], Package['wget']],
       path       => ['/usr/bin', '/usr/sbin', '/bin'],
-      unless     => "test -f ${plugin}",
+      creates    => $plugin,
     }
 
     file { "${plugin_dir}/${plugin}" :


### PR DESCRIPTION
Since this is a blind exec, it's re-downloading the plugins every puppet run, which then triggers the jenkins service notify.  This means that jenkins is needlessly restarted every time puppet agent runs, killing any currently running jobs.  This skips the exec if the file already exists (only for .hpi)