### PR TITLE
Few fixes to work with Centos 7

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -29,7 +29,7 @@ class jenkins::cli {
   $port = jenkins_port()
 
   # The jenkins cli command with required parameter(s)
-  $cmd = "java -jar ${jar} -s http://localhost:${port}"
+  $cmd = "/usr/bin/java -jar ${jar} -s http://localhost:${port}"
 
   # Reload all Jenkins config from disk (only when notified)
   exec { 'reload-jenkins':

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -136,6 +136,7 @@ define jenkins::plugin(
       cwd     => $plugin_dir,
       require => [File[$plugin_dir], Package['wget']],
       path    => ['/usr/bin', '/usr/sbin', '/bin'],
+      returns => [4, 0]
     }
 
     file { "${plugin_dir}/${plugin}" :


### PR DESCRIPTION
I have struggled with errors cause by those lines so I tought I would share as a pull request.
First one is about java when java executable is not in the path.
Second one is return code 4 when deleting non existing file with rm -Rf