### PR TITLE
Add ldap and roles

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -23,11 +23,23 @@ import com.cloudbees.plugins.credentials.common.*
 import com.cloudbees.plugins.credentials.domains.*
 import com.cloudbees.plugins.credentials.domains.*;
 import com.cloudbees.plugins.credentials.impl.*
-import com.cloudbees.plugins.credentials.impl.*;
-import hudson.plugins.sshslaves.*;
-import jenkins.model.*;
+import com.cloudbees.plugins.credentials.impl.*
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+import hudson.model.User;
+import hudson.plugins.sshslaves.*
+import hudson.security.ACL
+import hudson.security.AuthorizationStrategy
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy
+import hudson.security.GlobalMatrixAuthorizationStrategy
+import hudson.security.HudsonPrivateSecurityRealm
+import hudson.security.LDAPSecurityRealm
+import hudson.util.Secret;
+import jenkins.model.*
+import jenkins.security.ApiTokenProperty;
 
 class InvalidAuthenticationStrategy extends Exception{}
+class CanNotLoadJsonMapFileException extends Exception{}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Actions
@@ -37,72 +49,119 @@ class Actions {
   Actions(out) { this.out = out }
   def out
 
-  private credentials_for_username(String username) {
+  private static credentials_for_username(String username) {
     def username_matcher = CredentialsMatchers.withUsername(username)
     def available_credentials =
-      CredentialsProvider.lookupCredentials(
-        StandardUsernameCredentials.class,
-        Jenkins.getInstance(),
-        hudson.security.ACL.SYSTEM,
-        new SchemeRequirement("ssh")
-      )
-    
+            CredentialsProvider.lookupCredentials(
+                    StandardUsernameCredentials.class,
+                    Jenkins.getInstance(),
+                    ACL.SYSTEM,
+                    new SchemeRequirement("ssh")
+            )
+
     return CredentialsMatchers.firstOrNull(
-      available_credentials,
-      username_matcher
+            available_credentials,
+            username_matcher
     )
   }
 
-  /////////////////////////
-  // create or update user
-  /////////////////////////
-  void create_or_update_user(String user_name, String email, String password="", String full_name="", String public_keys="") {
-    def user = hudson.model.User.get(user_name)
-    user.setFullName(full_name)
-    
-    def email_param = new hudson.tasks.Mailer.UserProperty(email)
+  private loadJsonMap(String mapFileName) {
+    File mapFile = new File(mapFileName)
+    if (!mapFile.exists()) {
+      throw new CanNotLoadJsonMapFileException("JSON map file ${mapFileName} does not exist")
+    } else {
+      def slurper = new JsonSlurper()
+      return slurper.parseText(mapFile.text)
+    }
+  }
+
+  public getActionAndOptionMap(cliArgs) {
+    def cli = Jenkins.instance.pluginManager.uberClassLoader.findClass("groovy.util.CliBuilder").newInstance(usage: "puppet_helper.groovy - only called by puppet!")
+
+    cli._(longOpt:'action', args:1, required:true, "Action to invoke")
+
+    cli._(longOpt:'user_name', args:1, "Used in create_or_update_user, delete_user, user_info, create_or_update_credentials, delete_credentials, credential_info")
+
+    cli._(longOpt:'email', args:1, "Used in create_or_update_user")
+
+    cli._(longOpt:'password', args:1, "Used in create_or_update_user, create_or_update_credentials")
+
+    cli._(longOpt:'full_name', args:1, "Used in create_or_update_user")
+
+    cli._(longOpt:'public_keys', args:1, "Used in create_or_update_user")
+
+    cli._(longOpt:'description', args:1, "Used in create_or_update_credentials")
+
+    cli._(longOpt:'private_key', args:1, "Used in create_or_update_credentials")
+
+    cli._(longOpt:'security_model', args:1, "Used in set_security")
+
+    cli._(longOpt:'user_realm', args:1, "Used in set_security")
+
+    cli._(longOpt:'ldap_config_file', args:1, "JSON file containing LDAP configuration")
+    def opts = cli.parse(cliArgs)
+
+    def optMap = [:]
+
+    opts.getOptions().each { opt ->
+      if (opt.getLongOpt() != "action") {
+        optMap[opt.getLongOpt()] = opt.getValue() ?: ""
+      }
+    }
+
+    return [opts.action, optMap]
+  }
+
+  /**
+   * create or update user
+   */
+  void create_or_update_user(Map args) {
+    def user = User.get(args.username)
+    user.setFullName(args.full_name)
+
+    def email_param = new hudson.tasks.Mailer.UserProperty(args.email)
     user.addProperty(email_param)
-    
-    def pw_param = hudson.security.HudsonPrivateSecurityRealm.Details.fromPlainPassword(password)
+
+    def pw_param = HudsonPrivateSecurityRealm.Details.fromPlainPassword(args.password)
     user.addProperty(pw_param)
-    
-    if ( public_keys != "" ) {
-      def keys_param = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(public_keys)
+
+    if ( args.public_keys != "" ) {
+      def keys_param = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(args.public_keys)
       user.addProperty(keys_param)
     }
-    
+
     user.save()
   }
-  
-  /////////////////////////
-  // delete user
-  /////////////////////////
-  void delete_user(String user_name) {
-    def user = hudson.model.User.get(user_name, false)
+
+  /**
+   * delete user
+   */
+  void delete_user(Map args) {
+    def user = User.get(args.username, false)
     if (user != null) {
       user.delete()
     }
   }
-  
-  /////////////////////////
-  // current user
-  /////////////////////////
-  void user_info(String user_name) {
-    def user = hudson.model.User.get(user_name, false)
-  
+
+  /**
+   * current user
+   */
+  void user_info(Map args) {
+    def user = hudson.model.User.get(args.username, false)
+
     if(user == null) {
-        return null
+      return
     }
 
     def user_id = user.getId()
     def name = user.getFullName()
-    
+
     def email_address = null
     def emailProperty = user.getProperty(hudson.tasks.Mailer.UserProperty)
     if(emailProperty != null) {
       email_address = emailProperty.getAddress()
     }
-    
+
     def keys = null
     def keysProperty = user.getProperty(org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl)
     if(keysProperty != null) {
@@ -110,12 +169,12 @@ class Actions {
     }
 
     def token = null
-    def tokenProperty = user.getProperty(jenkins.security.ApiTokenProperty.class)
+    def tokenProperty = user.getProperty(ApiTokenProperty.class)
     if (tokenProperty != null) {
-        token = tokenProperty.getApiToken()
+      token = tokenProperty.getApiToken()
     }
-    
-    def builder = new groovy.json.JsonBuilder()
+
+    def builder = new JsonBuilder()
     builder {
       id user_id
       full_name name
@@ -123,136 +182,171 @@ class Actions {
       api_token token
       public_keys keys
     }
-  
+
     out.println(builder)
   }
-  
-  /////////////////////////
-  // create credentials
-  /////////////////////////
-  void create_or_update_credentials(String username, String password, String description="", String private_key="") {
+
+  /**
+   * create credentials
+   */
+  void create_or_update_credentials(Map args) {
     def global_domain = Domain.global()
     def credentials_store =
-      Jenkins.instance.getExtensionList(
-        'com.cloudbees.plugins.credentials.SystemCredentialsProvider'
-      )[0].getStore()
-    
+            Jenkins.instance.getExtensionList(
+                    'com.cloudbees.plugins.credentials.SystemCredentialsProvider'
+            )[0].getStore()
+
     def credentials
-    if (private_key == "" ) {
+    if (args.private_key == "" ) {
       credentials = new UsernamePasswordCredentialsImpl(
-        CredentialsScope.GLOBAL,
-        null,
-        description,
-        username,
-        password
+              CredentialsScope.GLOBAL,
+              null,
+              args.description,
+              args.username,
+              args.password
       )
     } else {
       def key_source
-      if (private_key.startsWith('-----BEGIN')) {
+      if (args.private_key.startsWith('-----BEGIN')) {
         key_source = new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(private_key)
       } else {
         key_source = new BasicSSHUserPrivateKey.FileOnMasterPrivateKeySource(private_key)
       }
       credentials = new BasicSSHUserPrivateKey(
-        CredentialsScope.GLOBAL,
-        null,
-        username,
-        key_source,
-        password,
-        description
+              CredentialsScope.GLOBAL,
+              null,
+              args.username,
+              key_source,
+              args.password,
+              args.description
       )
     }
-    
+
     // Create or update the credentials in the Jenkins instance
-    def existing_credentials = credentials_for_username(username)
-    
+    def existing_credentials = credentials_for_username(args.username)
+
     if(existing_credentials != null) {
       credentials_store.updateCredentials(
-        global_domain,
-        existing_credentials,
-        credentials
+              global_domain,
+              existing_credentials,
+              credentials
       )
     } else {
       credentials_store.addCredentials(global_domain, credentials)
     }
   }
-  
-  //////////////////////////
-  // delete credentials
-  //////////////////////////
-  void delete_credentials(String username) {
-    def existing_credentials = credentials_for_username(username)
-    
+
+  /**
+   * delete credentials
+   */
+  void delete_credentials(Map args) {
+    def existing_credentials = credentials_for_username(args.username)
+
     if(existing_credentials != null) {
-      def global_domain = com.cloudbees.plugins.credentials.domains.Domain.global()
+      def global_domain = Domain.global()
       def credentials_store =
-        Jenkins.instance.getExtensionList(
-          'com.cloudbees.plugins.credentials.SystemCredentialsProvider'
-        )[0].getStore()
+              Jenkins.instance.getExtensionList(
+                      'com.cloudbees.plugins.credentials.SystemCredentialsProvider'
+              )[0].getStore()
       credentials_store.removeCredentials(
-        global_domain,
-        existing_credentials
+              global_domain,
+              existing_credentials
       )
     }
   }
-  
-  ////////////////////////
-  // current credentials
-  ////////////////////////
-  void credential_info(String username) {
-    def credentials = credentials_for_username(username)
-    
+
+  /**
+   * current credentials
+   */
+  void credential_info(Map args) {
+    def credentials = credentials_for_username(args.username)
+
     if(credentials == null) {
-      return null
+      return
     }
-    
+
     def current_credentials = [
-      id:credentials.id,
-      description:credentials.description,
-      username:credentials.username
+            id:credentials.id,
+            description:credentials.description,
+            username:credentials.username
     ]
-  
+
     if ( credentials.hasProperty('password') ) {
-    current_credentials['password'] = credentials.password.plainText
+      current_credentials['password'] = credentials.password.plainText
     } else {
       current_credentials['private_key'] = credentials.privateKey
       current_credentials['passphrase'] = credentials.passphrase.plainText
     }
-  
-    def builder = new groovy.json.JsonBuilder(current_credentials)
+
+    def builder = new JsonBuilder(current_credentials)
     out.println(builder)
   }
-  
-  ////////////////////////
-  // set_security
-  ////////////////////////
-  /*
+
+  /**
    * Set up security for the Jenkins instance. This currently supports
    * only a small number of configurations. If authentication is enabled, it
-   * uses the internal user database.
-  */
-  void set_security(String security_model) {
+   * uses the internal user database if the user_realm isn't set or is set to
+   * 'internal', and LDAP if set to 'ldap'.
+   */
+  void set_security(Map args) {
     def instance = Jenkins.getInstance()
 
-    if (security_model == 'disabled') {
+    if (args.security_model == 'disabled') {
       instance.disableSecurity()
-      return null
+      return
+    }
+
+    Map ldapMap = [:]
+
+    if (args.ldap_config_file != null) {
+      ldapMap = loadJsonMap(args.load_config_file)
+    }
+
+    if (ldapMap.isEmpty() && args.user_realm == "ldap") {
+      throw new InvalidAuthenticationStrategy("LDAP user realm specified but no LDAP config provided")
     }
 
     def strategy
     def realm
-    switch (security_model) {
+    switch (args.security_model) {
       case 'full_control':
-        strategy = new hudson.security.FullControlOnceLoggedInAuthorizationStrategy()
-        realm = new hudson.security.HudsonPrivateSecurityRealm(false, false, null)
+        strategy = new FullControlOnceLoggedInAuthorizationStrategy()
         break
       case 'unsecured':
-        strategy = new hudson.security.AuthorizationStrategy.Unsecured()
-        realm = new hudson.security.HudsonPrivateSecurityRealm(false, false, null)
+        strategy = new AuthorizationStrategy.Unsecured()
+        break
+      case 'global_matrix':
+        strategy = new GlobalMatrixAuthorizationStrategy()
         break
       default:
         throw new InvalidAuthenticationStrategy()
     }
+
+    switch (args.user_realm) {
+      case ['internal', '']:
+        realm = new HudsonPrivateSecurityRealm(false, false, null)
+        break
+      case 'ldap':
+        realm = new LDAPSecurityRealm(ldapMap.server,
+                ldapMap.rootDN,
+                ldapMap.userSearchBase,
+                ldapMap.userSearch,
+                ldapMap.groupSearchBase,
+                ldapMap.groupSearchFilter,
+                null,
+                ldapMap.managerDN,
+                Secret.fromString(ldapMap.managerPasswordSecret ?: ""),
+                Boolean.parseBoolean(ldapMap.inhibitInferRootDN ?: "false"),
+                Boolean.parseBoolean(ldapMap.disableMailAddressResolver ?: "false"),
+                null,
+                null,
+                ldapMap.displayNameAttributeName,
+                ldapMap.mailAddressAttributeName)
+        break
+      default:
+        throw new InvalidAuthenticationStrategy()
+    }
+
     instance.setAuthorizationStrategy(strategy)
     instance.setSecurityRealm(realm)
   }
@@ -263,9 +357,13 @@ class Actions {
 ///////////////////////////////////////////////////////////////////////////////
 
 actions = new Actions(out)
-action = args[0]
+
+def argResult = actions.getActionAndOptionMap(args)
+def action = argResult[0]
+def optMap = argResult[1]
+
 if (args.length < 2) {
   actions."$action"()
 } else {
-  actions."$action"(*args[1..-1])
+  actions."$action"(optMap)
 }

--- a/manifests/credentials.pp
+++ b/manifests/credentials.pp
@@ -33,26 +33,26 @@ define jenkins::credentials (
       validate_string($private_key_or_path)
       exec { "create-jenkins-credentials-${title}":
         command   => join([
-          $::jenkins::cli_helper::helper_cmd,
-          'create_or_update_credentials',
-          $title,
-          "'${password}'",
-          "'${description}'",
-          "'${private_key_or_path}'",
-        ], ' '),
-        require   => Class['::jenkins::cli_helper'],
-        unless    => "${::jenkins::cli_helper::helper_cmd} credential_info ${title} | grep ${title}",
-        tries     => 3,
-        try_sleep => 5,
+                           $::jenkins::cli_helper::helper_cmd,
+                           '--action=create_or_update_credentials',
+                           "--username=${title}",
+                           "--password='${password}'",
+                           "--description='${description}'",
+                           "--private_key='${private_key_or_path}'",
+                           ], ' '),
+                         require   => Class['::jenkins::cli_helper'],
+                         unless    => "${::jenkins::cli_helper::helper_cmd} credential_info ${title} | grep ${title}",
+                         tries     => 3,
+                         try_sleep => 5,
       }
     }
     'absent': {
       exec { "delete-jenkins-credentials-${title}":
         command   => join([
-          $::jenkins::cli_helper::helper_cmd,
-          'delete_credentials',
-          $title,
-        ], ' '),
+                           $::jenkins::cli_helper::helper_cmd,
+                           '--action=delete_credentials',
+                           "--username=${title}",
+                           ], ' '),
         require   => Class['::jenkins::cli_helper'],
         tries     => 3,
         try_sleep => 5,

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -36,12 +36,12 @@ define jenkins::user (
       exec { "create-jenkins-user-${title}":
         command => join([
           $::jenkins::cli_helper::helper_cmd,
-          'create_or_update_user',
-          $title,
-          $email,
-          "'${password}'",
-          "'${full_name}'",
-          "'${public_key}'",
+          '--action=create_or_update_user',
+          "--username=${title}",
+          "--email=${email}",
+          "--password='${password}'",
+          "--full_name='${full_name}'",
+          "--public_key='${public_key}'",
         ], ' '),
         require => Class['::jenkins::cli_helper'],
       }
@@ -50,8 +50,8 @@ define jenkins::user (
       exec { "delete-jenkins-user-${title}":
         command => join([
           $::jenkins::cli_helper::helper_cmd,
-          'delete_user',
-          $title,
+          '--action=delete_user',
+          "--username=${title}",
         ], ' '),
         require => Class['::jenkins::cli_helper'],
       }

--- a/templates/ldap_args.json.erb
+++ b/templates/ldap_args.json.erb
@@ -1,0 +1,1 @@
+<%= require 'json'; JSON.pretty_generate(@ldapconfig) %>

--- a/templates/perm_args.json.erb
+++ b/templates/perm_args.json.erb
@@ -1,0 +1,1 @@
+<%= require 'json'; JSON.pretty_generate(@permissions) %>


### PR DESCRIPTION
So this is very very preliminary and annoyingly chock full of my IDE reindenting the shit out of things, but...

* Rework puppet_helper.groovy to use groovy.util.CliBuilder, so that we don't have to worry about things like order of arguments and the like. Not huuuuuge yet, but I think it's valuable, so that we could do null values for arguments etc.
* As a result, change all the methods to take a Map as their only argument - this is so that the magic method dispatch stuff doesn't need to know the names of the arguments for each method. That map is generated from CliBuilder's results (with some twiddling to always have unspecified arguments show up as an empty string, rather than null, just to make things safer), and then the values there are accessed by "args.whatever_argument_flag_name".
** The above two may be excessive, I admit. But future proofing, yo. Future proofing.
* In security.pp, add ldapconfig and permissions variables, intended to be specified in hiera. This stuff is the gnarly part - to get hashes in particular from Puppet to something puppet_helper.groovy can know about is...yeah. So we serialize these down to /tmp/something.json via templates, and then pass the path to those files as arguments to puppet_helper. puppet_helper then knows to slurp them in and use 'em. Woo.
* And then we take the new possible values for security_model (global_matrix) and user_realm (ldap) - if they're selected, we instantiate/populate the objects using the data we just deserialized. Tada!

So yeah, no idea if it actually *works* yet. But I wanted to throw this up to make sure I wasn't too batshit. As I write this, I'm thinking I probably am in some parts (most notably the CliBuilder and args as Maps bits - I'm not 100% sure we actually *need* either of those things as this currently stands, but they both come in handy for further extensions in the future). So tell me what's too crazy and I will clean it out.