### PR TITLE
Make creation of user optional

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -7,7 +7,7 @@
 #   create this content from a template or any other mean.
 #
 # update_url = undef
-#   
+#
 define jenkins::plugin(
   $version         = 0,
   $manage_config   = false,
@@ -18,6 +18,7 @@ define jenkins::plugin(
   $username        = 'jenkins',
   $group           = 'jenkins',
   $enabled         = true,
+  $create_user     = true,
 ) {
   include ::jenkins::params
 
@@ -65,18 +66,19 @@ define jenkins::plugin(
 
   }
 
-  if (!defined(Group[$group])) {
-    group { $group :
-      ensure  => present,
-      require => Package['jenkins'],
+  if $create_user {
+    if (!defined(Group[$group])) {
+      group { $group :
+        ensure  => present,
+        require => Package['jenkins'],
+      }
     }
-  }
-
-  if (!defined(User[$username])) {
-    user { $username :
-      ensure  => present,
-      home    => $plugin_parent_dir,
-      require => Package['jenkins'],
+    if (!defined(User[$username])) {
+      user { $username :
+        ensure  => present,
+        home    => $plugin_parent_dir,
+        require => Package['jenkins'],
+      }
     }
   }
 

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -99,7 +99,6 @@ describe 'jenkins::plugin' do
     it { should contain_exec('download-myplug').with(:environment => ["http_proxy=proxy.company.com:8080", "https_proxy=proxy.company.com:8080"]) }
   end
 
-
   describe 'with a custom update center' do
     shared_examples 'execute the right fetch command' do
       it 'should wget the plugin' do
@@ -152,6 +151,15 @@ describe 'jenkins::plugin' do
 
         include_examples 'execute the right fetch command'
       end
+    end
+  end
+  context 'when not installing users' do
+    let :params do
+      {'create_user' => false}
+    end
+    it 'should not create user or group' do
+      should_not contain_group('jenkins')
+      should_not contain_user('jenkins')
     end
   end
 


### PR DESCRIPTION
Currently, the creation of jenkins user
and group is protected by if !defined. This
can be extremely annoying in cases where code
is trying to install a competing jenkins user/group.

In my specific case, I'm blocked by this code
leading to duplicate jenkins users (and I need
my definition to be created first). In general,
I thought that these kinds of issue were resolvable
via enusre that classes were including in a certain
order, but I cannot seem to resove it in my specific use
case which involves:
* nested class includes
* serialized user resources from hiera
* create_resources