### PR TITLE
Cleanup metadata.json for better mechanical score

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,10 +2,10 @@
   "name": "rtyler-jenkins",
   "version": "1.3.0",
   "author": "R. Tyler Croy <tyler@monkeypox.org>",
-  "license": "Licensed under (Apache 2.0)",
+  "license": "Apache-2.0",
   "summary": "Manage the Jenkins continuous integration service with Puppet",
   "source": "https://github.com/jenkinsci/puppet-jenkins",
-  "project_page": "(https://forge.puppetlabs.com/rtyler/puppet-jenkins)",
+  "project_page": "https://forge.puppetlabs.com/rtyler/puppet-jenkins",
   "issues_url": "https://github.com/jenkinsci/puppet-jenkins/issues",
   "tags": ["jenkins", "jenkinsci"],
   "operatingsystem_support": [
@@ -19,9 +19,9 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3" },
-    { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1" },
-    { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.0.0 < 5.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0" },
+    { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0" },
+    { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0" }
   ]
 }


### PR DESCRIPTION
Puppet Forge has been marking the mechanical metadate score down because
of issues with the metadata.json

This change cleans up the project page URL so that it is verifiable and
will actually work correctly when clicking on the link from Puppet Forge

This change modifies the license clause to be SPDX compliant

This change adds bounds to the dependencies as having unbounded ranges
lowers the score. The current bounds should be large enough to handle
future versions properly for at least a little while.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>