### PR TITLE
add firewall module as a dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,9 +19,10 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.0.0 < 5.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0" },
-    { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0" },
-    { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.0.0 < 5.0.0" },
+    { "name": "puppetlabs/firewall", "version_requirement": ">= 1.0.0 < 2.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0.0" },
+    { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
+    { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" }
   ]
 }


### PR DESCRIPTION
also fix versions: x.y is not a valid version, x.y.z. is (according to gepetto)