### PR TITLE
Set ubuntu default directory to /etc/default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@ class jenkins::params {
   $cli_try_sleep         = 10
 
   case $::osfamily {
-    'Debian': {
+    'Debian', 'Ubuntu': {
       $libdir = '/usr/share/jenkins'
     }
     default: {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -20,7 +20,7 @@ class jenkins::repo {
           Anchor['jenkins::repo::end']
       }
 
-      'Debian': {
+      'Debian', 'Ubuntu': {
         class { 'jenkins::repo::debian': }
         Anchor['jenkins::repo::begin'] ->
           Class['jenkins::repo::debian'] ->

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -133,7 +133,7 @@ class jenkins::slave (
 
 # customizations based on the OS family
   case $::osfamily {
-    Debian: {
+    'Ubuntu', 'Debian': {
       $defaults_location = '/etc/default'
 
       package { 'daemon':

--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -6,6 +6,7 @@ define jenkins::sysconfig ( $value ) {
     'RedHat' => '/etc/sysconfig',
     'Suse'   => '/etc/sysconfig',
     'Debian' => '/etc/default',
+    'Ubuntu' => '/etc/default',
     default  => fail( "Unsupported OSFamily ${::osfamily}" )
   }
 


### PR DESCRIPTION
Currently the path for Jenkins slave config on Ubuntu is ```/etc/sysconfig``` which is the default which doesn't exist in the base installation, to work around this I created a file resource which the class depended on;
```
file { '/etc/sysconfig':
  ensure => 'directory'
}

class { '::jenkins::slave':
  require => File['/etc/sysconfig']
}
```
It would be nice if it used the same as the Debian installation path.