### PR TITLE
Direct package

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@ fixtures:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
     java: "git://github.com/puppetlabs/puppetlabs-java"
     zypprepo: "git://github.com/deadpoint/puppet-zypprepo.git"
+    staging: "https://github.com/nanliu/puppet-staging"
   symlinks:
     "jenkins": "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ To quickly try this module with the puppet module tool:
     notice: Finished catalog run in 27.46 seconds
 
 ### Overriding the jenkins package name
+It's possible to specify a different package name to the default `jenkins` if you wish:
+```
+class { 'jenkins':
+  package_name => 'jenkins_custom',
+}
+```
 
 ### Installing from a hosted RPM
 Sometimes you don't have an RPM repository available and are not allowed to 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The dependencies for this module currently are:
 * [apt module](http://forge.puppetlabs.com/puppetlabs/apt) (for Debian/Ubuntu users)
 * [java module](http://github.com/puppetlabs/puppetlabs-java)
 * [zypprepo](https://forge.puppetlabs.com/darin/zypprepo) (for Suse users)
-
+* [staging module](https://forge.puppetlabs.com/nanliu/staging)
 
 ### Depending on Jenkins
 
@@ -261,3 +261,16 @@ To quickly try this module with the puppet module tool:
     notice: /Stage[main]/Jenkins::Service/Service[jenkins]/ensure: ensure changed 'stopped' to 'running'
     notice: Finished catalog run in 27.46 seconds
 
+### Overriding the jenkins package name
+
+### Installing from a hosted RPM
+Sometimes you don't have an RPM repository available and are not allowed to 
+directly install from repositories on the Internet.  In this case, you can 
+still install Jenkins with this module by hosting the jenkins RPM file 
+somewhere accessible (http server, S3 bucket, etc.) and tell
+
+```
+class { 'jenkins':
+  direct_download => 'http://myserver/rpms/jenkins-x.xxx-1-1.rpm',
+}
+``` 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,9 +16,6 @@ class jenkins::config {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  include jenkins::package
-
-  Class['Jenkins::Package']->Class['Jenkins::Config']
   create_resources( 'jenkins::sysconfig', $::jenkins::config_hash )
 }
 

--- a/manifests/direct_download.pp
+++ b/manifests/direct_download.pp
@@ -6,22 +6,25 @@ class jenkins::direct_download {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
-
   validate_string($::jenkins::package_provider)
   validate_string($::jenkins::direct_download)
   validate_absolute_path($::jenkins::package_cache_dir)
-  if $::jenkins::version {
-    validate_string($::jenkins::version)  
+
+  # directory for temp files
+  file { $::jenkins::package_cache_dir:
+    ensure => directory,
+    owner  => "root",
+    group  => "root",
+    mode   => "0644",
   }
 
-  # stdlib 4.6 has 'basename'
-  #$package_file = basename($::jenkins::download_url)
+  # equivalent to basename() - get the filename
   $package_file = regsubst($::jenkins::direct_download, '(.*?)([^/]+)$', '\2')
   $local_file = "${::jenkins::package_cache_dir}/${package_file}"
   
   validate_absolute_path($local_file)
 
-  if $::jenkins::version {
+  if $::jenkins::version != 'absent' {
     # make download optional if we are removing...
     staging::file { $package_file:
       source  => $jenkins::direct_download,

--- a/manifests/direct_download.pp
+++ b/manifests/direct_download.pp
@@ -13,9 +13,9 @@ class jenkins::direct_download {
   # directory for temp files
   file { $::jenkins::package_cache_dir:
     ensure => directory,
-    owner  => "root",
-    group  => "root",
-    mode   => "0644",
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
   }
 
   # equivalent to basename() - get the filename
@@ -27,15 +27,15 @@ class jenkins::direct_download {
   if $::jenkins::version != 'absent' {
     # make download optional if we are removing...
     staging::file { $package_file:
-      source  => $jenkins::direct_download,
-      target  => $local_file,
-      before  => Package[$::jenkins::package_name],
+      source => $jenkins::direct_download,
+      target => $local_file,
+      before => Package[$::jenkins::package_name],
     }
-  } 
+  }
   
   package { $::jenkins::package_name:
     ensure   => $::jenkins::version,
     provider => $::jenkins::package_provider,
     source   => $local_file,
-  } 
+  }
 }

--- a/manifests/direct_download.pp
+++ b/manifests/direct_download.pp
@@ -2,7 +2,7 @@
 # Support for directly downloading a package file - for when no repository
 # is available
 #
-class jenkins::direct_download {  
+class jenkins::direct_download {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }

--- a/manifests/direct_download.pp
+++ b/manifests/direct_download.pp
@@ -1,0 +1,38 @@
+# 
+# Support for directly downloading a package file - for when no repository
+# is available
+#
+class jenkins::direct_download {  
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
+  validate_string($::jenkins::package_provider)
+  validate_string($::jenkins::direct_download)
+  validate_absolute_path($::jenkins::package_cache_dir)
+  if $::jenkins::version {
+    validate_string($::jenkins::version)  
+  }
+
+  # stdlib 4.6 has 'basename'
+  #$package_file = basename($::jenkins::download_url)
+  $package_file = regsubst($::jenkins::direct_download, '(.*?)([^/]+)$', '\2')
+  $local_file = "${::jenkins::package_cache_dir}/${package_file}"
+  
+  validate_absolute_path($local_file)
+
+  if $::jenkins::version {
+    # make download optional if we are removing...
+    staging::file { $package_file:
+      source  => $jenkins::direct_download,
+      target  => $local_file,
+      before  => Package[$::jenkins::package_name],
+    }
+  } 
+  
+  package { $::jenkins::package_name:
+    ensure   => $::jenkins::version,
+    provider => $::jenkins::package_provider,
+    source   => $local_file,
+  } 
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,24 +162,20 @@ class jenkins(
     }
   }
 
-  if ! $direct_download and $repo {
-    include jenkins::repo
-    $repo_ = true
-  } elsif direct_download {
+  if $direct_download {
     $repo_ = false
-    file { $package_cache_dir:
-      ensure => directory,
-      owner  => "root",
-      group  => "root",
-      mode   => "0644",
-    }
-    include jenkins::direct_download
     $jenkins_package_class = 'jenkins::direct_download'
   } else {
-    include jenkins::package
-    $jenkins_package_class = 'jenkins::package'
+    $jenkins_package_class = 'jenkins::package'  
+    if $repo {
+      $repo_ = true
+      include jenkins::repo
+    } else {
+      $repo_ = false
+    }
   }
-
+  include $jenkins_package_class
+  
   include jenkins::config
   include jenkins::plugins
   include jenkins::jobs

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,18 @@
 #   this module.
 #   This is for folks that use a custom repo, or the like.
 #
+# package_name = 'jenkins'
+#   Optionally override the package name
+#
+# direct_download = 'http://...'
+#   Ignore repostory based package installation and download and install 
+#   package directly.  Leave as `false` (the default) to download using your
+#   OS package manager
+#
+# package_cache_dir  = '/var/cache/jenkins_pkgs'
+#   Optionally specify an alternate location to download packages to when using
+#   direct_download
+#
 # service_enable = true (default)
 #   Enable (or not) the jenkins service
 #
@@ -109,6 +121,10 @@ class jenkins(
   $version            = $jenkins::params::version,
   $lts                = $jenkins::params::lts,
   $repo               = $jenkins::params::repo,
+  $package_name       = $jenkins::params::package_name,
+  $direct_download    = false,
+  $package_cache_dir  = $jenkins::params::package_cache_dir,
+  $package_provider   = $jenkins::params::package_provider,
   $service_enable     = $jenkins::params::service_enable,
   $service_ensure     = $jenkins::params::service_ensure,
   $config_hash        = {},
@@ -146,11 +162,24 @@ class jenkins(
     }
   }
 
-  if $repo {
+  if ! $direct_download and $repo {
     include jenkins::repo
+    $repo_ = true
+  } elsif direct_download {
+    $repo_ = false
+    file { $package_cache_dir:
+      ensure => directory,
+      owner  => "root",
+      group  => "root",
+      mode   => "0644",
+    }
+    include jenkins::direct_download
+    $jenkins_package_class = 'jenkins::direct_download'
+  } else {
+    include jenkins::package
+    $jenkins_package_class = 'jenkins::package'
   }
 
-  include jenkins::package
   include jenkins::config
   include jenkins::plugins
   include jenkins::jobs
@@ -177,7 +206,7 @@ class jenkins(
   }
 
   Anchor['jenkins::begin'] ->
-    Class['jenkins::package'] ->
+    Class[$jenkins_package_class] ->
       Class['jenkins::config'] ->
         Class['jenkins::plugins'] ~>
           Class['jenkins::service'] ->
@@ -195,11 +224,11 @@ class jenkins(
   if $install_java {
     Anchor['jenkins::begin'] ->
       Class['java'] ->
-        Class['jenkins::package'] ->
+        Class[$jenkins_package_class] ->
           Anchor['jenkins::end']
   }
 
-  if $repo {
+  if $repo_ {
     Anchor['jenkins::begin'] ->
       Class['jenkins::repo'] ->
         Class['jenkins::package'] ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,7 +166,7 @@ class jenkins(
     $repo_ = false
     $jenkins_package_class = 'jenkins::direct_download'
   } else {
-    $jenkins_package_class = 'jenkins::package'  
+    $jenkins_package_class = 'jenkins::package'
     if $repo {
       $repo_ = true
       include jenkins::repo

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -10,7 +10,7 @@ class jenkins::package {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  package { 'jenkins' :
-    ensure => $::jenkins::version;
+  package { $::jenkins::package_name:
+    ensure => $::jenkins::version,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,10 +13,17 @@ class jenkins::params {
   $port                  = '8080'
   $cli_tries             = 10
   $cli_try_sleep         = 10
+  $package_cache_dir     = '/var/cache/jenkins_pkgs'
+  $package_name          = 'jenkins'
 
   case $::osfamily {
     'Debian': {
-      $libdir = '/usr/share/jenkins'
+      $libdir           = '/usr/share/jenkins'
+      $package_provider = 'dpkg' 
+    }
+    'RedHat': {
+      $libdir           = '/usr/lib/jenkins'
+      $package_provider = 'rpm'
     }
     default: {
       $libdir = '/usr/lib/jenkins'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class jenkins::params {
   case $::osfamily {
     'Debian': {
       $libdir           = '/usr/share/jenkins'
-      $package_provider = 'dpkg' 
+      $package_provider = 'dpkg'
     }
     'RedHat': {
       $libdir           = '/usr/lib/jenkins'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class jenkins::params {
     }
     default: {
       $libdir = '/usr/lib/jenkins'
+      $package_provider = false
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -20,8 +20,9 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.0.0 < 5.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0" },
-    { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0" },
-    { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0" }
+    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0.0" },
+    { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
+    { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
+    { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.0.0 < 5.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.0.0 < 5.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0" },
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0" }

--- a/spec/classes/jenkins_direct_download_spec.rb
+++ b/spec/classes/jenkins_direct_download_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe 'jenkins', :type => :module do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
+  let(:params) { { :direct_download => 'http://local.space/jenkins.rpm' } }
+
+  describe 'direct_download' do
+
+    context 'default' do
+      it { should contain_package('jenkins').with_installed }
+      it { should_not contain_class('jenkins::package') }
+      it { should contain_class('jenkins::direct_download') }
+    end
+
+    context 'with version' do
+      let(:params) { { :version => '1.2.3' } }
+      it { should contain_package('jenkins').with_ensure('1.2.3') }
+    end
+
+    context 'package dir created' do
+      it { should contain_file('/var/cache/jenkins_pkgs').with_ensure('directory') }
+    end
+
+    context 'staging resource created' do
+      it { should contain_staging__file('jenkins.rpm').with_source('http://local.space/jenkins.rpm') }
+    end
+
+    context 'package removable' do
+      let (:params) { { :version => 'absent', :direct_download => 'http://local.space/jenkins.rpm' } }
+      it { should_not contain_staging__file('jenkins.rpm') }
+      it { should contain_package('jenkins').with_ensure('absent') }
+    end
+
+    context 'unsupported provider fails' do
+      let (:params) { { :package_provider => false, :direct_download => 'http://local.space/jenkins.rpm' } }
+      it do 
+        expect { should compile }.to raise_error
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Hi There,

Thanks for your hard work on this package.  I've developed a PR you may be interested in which adds support for directly downloading the RPM package from a regular HTTP server.

This is useful for places that both don't have their own yum repository or access to download from the Internet.

The PR works by adding a new parameter to the `jenkins` class called `direct_download` which the user can use to specify the whole remote path to the package file which can then be downloaded and installed.

I've also fully documented this, added an RSpec test class, added this new class into the anchors your using and fixed the metadata.json file (there were invalid version numbers and I'm using `nanlui/staging` to download remote files).

Hope this can be merged if at all possible.

Thanks,
Geoff