### PR TITLE
Support getting Jenkins .xml job descriptions from Puppet fileserver

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -20,6 +20,7 @@ define jenkins::job(
   $config,
   $jobname  = $title,
   $enabled  = 1,
+  $sourced  = 0,
   $ensure   = 'present',
 ){
 
@@ -29,7 +30,11 @@ define jenkins::job(
     }
   } else {
     jenkins::job::present { $title:
-      config  => $config,
+      if ($sourced) {
+        config => file($config),
+      } else {
+        config  => $config,
+      }
       jobname => $jobname,
       enabled => $enabled,
     }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -29,15 +29,18 @@ define jenkins::job(
       jobname => $jobname,
     }
   } else {
-    jenkins::job::present { $title:
-      if ($sourced) {
+    if ($sourced) {
+      jenkins::job::present { $title:
         config => file($config),
-      } else {
-        config  => $config,
+        jobname => $jobname,
+        enabled => $enabled,
       }
-      jobname => $jobname,
-      enabled => $enabled,
+    } else {
+      jenkins::job::present { $title:
+        config  => $config,
+        jobname => $jobname,
+        enabled => $enabled,
+      }
     }
   }
-
 }


### PR DESCRIPTION
Jenkins-job-builder is too brittle for me so I have returned to simply storing the full `config.xml` jobs in my Puppet repo.

If I use `jenkins::job_hash` as-is, it would require the XML raw job to be pasted into hiera config which is difficult to read. This PR adds a simple 'sourced' condition to get the module to get the config from a puppet filie server.. e.g. this permits the following cleaner syntax in a hiera conf:

```
jenkins::job_hash:
  genersys-outgoing-promotion-file-writer:
    config: 'itv_genersys_data/jenkins/qa1/genersys-outgoing-promotion-file-writer.xml'
    sourced: 1
  genersys-outgoing-promotion-ftp-poller:
    config: 'itv_genersys_data/jenkins/qa1/genersys-outgoing-promotion-ftp-poller.xml'
    sourced: 1
```

Cheers,
Gavin