### PR TITLE
Escape job names for shell commands

### DIFF
--- a/manifests/job/absent.pp
+++ b/manifests/job/absent.pp
@@ -31,9 +31,9 @@ define jenkins::job::absent(
   # Delete the job
   exec { "jenkins delete-job ${jobname}":
     path      => ['/usr/bin', '/usr/sbin', '/bin'],
-    command   => "${jenkins::cli::cmd} delete-job ${jobname}",
+    command   => "${jenkins::cli::cmd} delete-job \"${jobname}\"",
     logoutput => false,
-    onlyif    => "test -f ${config_path}",
+    onlyif    => "test -f \"${config_path}\"",
     require   => Exec['jenkins-cli'],
   }
 

--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -58,10 +58,9 @@ define jenkins::job::present(
   }
 
   # Use Jenkins CLI to create the job
-  $cat_config = "cat ${tmp_config_path}"
-  $create_job = "${jenkins_cli} create-job ${jobname}"
+  $cat_config = "cat \"${tmp_config_path}\""
+  $create_job = "${jenkins_cli} create-job \"${jobname}\""
   exec { "jenkins create-job ${jobname}":
-    path    => ['/usr/bin', '/usr/sbin', '/bin'],
     command => "${cat_config} | ${create_job}",
     creates => [$config_path, "${job_dir}/builds"],
     require => File[$tmp_config_path],
@@ -70,7 +69,6 @@ define jenkins::job::present(
   # Use Jenkins CLI to update the job if it already exists
   $update_job = "${jenkins_cli} update-job ${jobname}"
   exec { "jenkins update-job ${jobname}":
-    path    => ['/usr/bin', '/usr/sbin', '/bin'],
     command => "${cat_config} | ${update_job}",
     onlyif  => "test -e ${config_path}",
     unless  => "diff -b -q ${config_path} ${tmp_config_path}",
@@ -81,9 +79,8 @@ define jenkins::job::present(
   # Enable or disable the job (if necessary)
   if ($enabled == 1) {
     exec { "jenkins enable-job ${jobname}":
-      path    => ['/usr/bin', '/usr/sbin', '/bin'],
-      command => "${jenkins_cli} enable-job ${jobname}",
-      onlyif  => "cat ${config_path} | grep '<disabled>true'",
+      command => "${jenkins_cli} enable-job \"${jobname}\"",
+      onlyif  => "cat \"${config_path}\" | grep '<disabled>true'",
       require => [
         Exec["jenkins create-job ${jobname}"],
         Exec["jenkins update-job ${jobname}"],
@@ -91,9 +88,8 @@ define jenkins::job::present(
     }
   } else {
     exec { "jenkins disable-job ${jobname}":
-      command => "${jenkins_cli} disable-job ${jobname}",
-      path    => ['/usr/bin', '/usr/sbin', '/bin'],
-      onlyif  => "cat ${config_path} | grep '<disabled>false'",
+      command => "${jenkins_cli} disable-job \"${jobname}\"",
+      onlyif  => "cat \"${config_path}\" | grep '<disabled>false'",
       require => [
         Exec["jenkins create-job ${jobname}"],
         Exec["jenkins update-job ${jobname}"],


### PR DESCRIPTION
Escape names when using the CLI to create or remove jobs.

This allows job names s to contain spaces, brackets and braces.