### PR TITLE
Change apt key to full fingerprint

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -14,7 +14,7 @@ class jenkins::repo::debian
       location    => 'http://pkg.jenkins-ci.org/debian-stable',
       release     => 'binary/',
       repos       => '',
-      key         => 'D50582E6',
+      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
       key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
       include_src => false,
     }
@@ -24,7 +24,7 @@ class jenkins::repo::debian
       location    => 'http://pkg.jenkins-ci.org/debian',
       release     => 'binary/',
       repos       => '',
-      key         => 'D50582E6',
+      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
       key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
       include_src => false,
     }


### PR DESCRIPTION
Since a few days puppetlabs/apt module throw a warnings if a full fingerprint
is not used.