### PR TITLE
pin puppetlabs-apt fixtures version to 1.8.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,8 @@
 fixtures:
   repositories:
-    apt: "git://github.com/puppetlabs/puppetlabs-apt"
+    apt:
+      repo: "git://github.com/puppetlabs/puppetlabs-apt"
+      ref: "1.8.0"
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
     java: "git://github.com/puppetlabs/puppetlabs-java"
     zypprepo: "git://github.com/deadpoint/puppet-zypprepo.git"


### PR DESCRIPTION
The 2.0.0 release of puppetlabs-apt includes major breaking changes to the API.
The metadata.json already specifies puppetlabs-apt as < 2.0 but the fixtures
version was free floating.