### PR TITLE
remove rspec gem ~> 2.99.0 constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rake', '>= 10.1.1'
-gem 'rspec', '~> 2.99.0'
 gem 'rspec-its'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'rspec-puppet', '>= 1.0.1'


### PR DESCRIPTION
beaker-rspec 5 requires rspec >= 3