### PR TITLE
use mainline puppetlabs_spec_helper gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rspec', '~> 2.99.0'
 gem 'rspec-its'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'rspec-puppet', '>= 1.0.1'
-gem 'puppetlabs_spec_helper', :github => 'jenkins-infra/puppetlabs_spec_helper'
+gem 'puppetlabs_spec_helper',   :require => false
 gem 'puppet-syntax', '>= 1.1.0'
 gem 'json'
 gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.5'


### PR DESCRIPTION
The 'jenkins-infra/puppetlabs_spec_helper' fork is significantly behind the
mainline gem release.