### PR TITLE
remove puppet module versions constraints from beaker setup

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,11 +29,11 @@ RSpec.configure do |c|
       copy_module_to(host, :source => proj_root, :module_name => 'jenkins')
       shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
 
-      on host, puppet('module install puppetlabs-stdlib --version >= 2.0.0'), { :acceptable_exit_codes => [0] }
-      on host, puppet('module install puppetlabs-java --version >= 1.0.1'), { :acceptable_exit_codes => [0] }
-      on host, puppet('module install puppetlabs-apt --version >= 0.0.3'), { :acceptable_exit_codes => [0] }
+      on host, puppet('module install puppetlabs-stdlib'), { :acceptable_exit_codes => [0] }
+      on host, puppet('module install puppetlabs-java'), { :acceptable_exit_codes => [0] }
+      on host, puppet('module install puppetlabs-apt'), { :acceptable_exit_codes => [0] }
 
-      on host, puppet('module install darin-zypprepo --version >= 1.0.1'), { :acceptable_exit_codes => [0] }
+      on host, puppet('module install darin-zypprepo'), { :acceptable_exit_codes => [0] }
     end
   end
 end


### PR DESCRIPTION
Resolves this error:

    /home/jhoblitt/github/puppet-jenkins/.bundle/ruby/2.1.0/gems/beaker-2.7.1/lib/beaker/host.rb:378:in `exec': Host 'ubuntu-server-12042-x64' exited with 1 running: (Beaker::Host::CommandFailure)
     puppet module install puppetlabs-stdlib --version >= 2.0.0
    Last 10 lines of output were:
        Warning: Setting templatedir is deprecated. See http://links.puppetlabs.com/env-settings-deprecations
           (at /usr/lib/ruby/vendor_ruby/puppet/settings.rb:1139:in `issue_deprecation_warning')
        Error: Could not install module 'puppetlabs-stdlib' (???)
          No version of 'puppetlabs-stdlib' can satisfy all dependencies
            Use `puppet module install --ignore-dependencies` to install only this module