### PR TITLE
remove unnecessary whitespace from $::jenkins::cli_helper::helper_cmd

### DIFF
--- a/manifests/cli_helper.pp
+++ b/manifests/cli_helper.pp
@@ -24,13 +24,16 @@ class jenkins::cli_helper (
   if $ssh_keyfile {
     $auth_arg = "-i ${ssh_keyfile}"
   } else {
-    $auth_arg = ''
+    $auth_arg = undef
   }
-  $helper_cmd = join([
-    '/usr/bin/java',
-    "-jar ${::jenkins::cli::jar}",
-    "-s http://127.0.0.1:${port}",
-    $auth_arg,
-    "groovy ${helper_groovy}",
-  ], ' ')
+  $helper_cmd = join(
+    delete_undef_values([
+      '/usr/bin/java',
+      "-jar ${::jenkins::cli::jar}",
+      "-s http://127.0.0.1:${port}",
+      $auth_arg,
+      "groovy ${helper_groovy}",
+    ]),
+    ' '
+  )
 }


### PR DESCRIPTION
If $ssh_keyfile was not specified, an extra two spaces would appear in
$helper_cmd.  This was harmless but annoying when unit testing the value of
that variable.