### PR TITLE
change puppetlabs/stdlib version dep to >= 4.6.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 2.0.0 < 5.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0 < 5.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0.0" },
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },


### PR DESCRIPTION
To allow usage of validate_integer()