### PR TITLE
Fix compatibility with apt module

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -14,9 +14,8 @@ class jenkins::repo::debian
       location    => 'http://pkg.jenkins-ci.org/debian-stable',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      key         => {  'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+                        'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key' },
     }
   }
   else {
@@ -24,9 +23,8 @@ class jenkins::repo::debian
       location    => 'http://pkg.jenkins-ci.org/debian',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      key         => {  'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+                        'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key' },
     }
   }
 


### PR DESCRIPTION
- key_source parameter was removed, key parameter should be used instead.
- include_src was also removed and set to false by default, there's no need to
  override it anymore.