### PR TITLE
set user on exec resources in jenkins::plugin define

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -139,6 +139,7 @@ define jenkins::plugin(
       path    => ['/usr/bin', '/usr/sbin', '/bin'],
       onlyif  => "test -f ${plugin_dir}/${name}.jpi -a ! -f ${plugin_dir}/${name}.jpi.pinned",
       before  => Exec["download-${name}"],
+      user    => $username,
     }
 
     # if $source is specified, it overrides any other URL construction
@@ -152,6 +153,7 @@ define jenkins::plugin(
       cwd     => $plugin_dir,
       require => [File[$plugin_dir], Package['wget']],
       path    => ['/usr/bin', '/usr/sbin', '/bin'],
+      user    => $username,
     }
 
     file { "${plugin_dir}/${plugin}" :

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -24,20 +24,26 @@ describe 'jenkins::plugin' do
 
 
   describe 'without version' do
-    it { should contain_exec('download-myplug').with(
-      :command      => 'rm -rf myplug myplug.hpi myplug.jpi && wget --no-check-certificate http://updates.jenkins-ci.org/latest/myplug.hpi',
-      :environment  => nil
-    )}
+    it do
+      should contain_exec('download-myplug').with(
+        :command     => 'rm -rf myplug myplug.hpi myplug.jpi && wget --no-check-certificate http://updates.jenkins-ci.org/latest/myplug.hpi',
+        :user        => 'jenkins',
+        :environment => nil
+      )
+    end
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
   end
 
   describe 'with version' do
     let(:params) { { :version => '1.2.3' } }
 
-    it { should contain_exec('download-myplug').with(
-      :command      => 'rm -rf myplug myplug.hpi myplug.jpi && wget --no-check-certificate http://updates.jenkins-ci.org/download/plugins/myplug/1.2.3/myplug.hpi',
-      :environment  => nil
-    ) }
+    it do
+      should contain_exec('download-myplug').with(
+        :command     => 'rm -rf myplug myplug.hpi myplug.jpi && wget --no-check-certificate http://updates.jenkins-ci.org/download/plugins/myplug/1.2.3/myplug.hpi',
+        :user        => 'jenkins',
+        :environment => nil
+      )
+    end
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
   end
 
@@ -96,7 +102,14 @@ describe 'jenkins::plugin' do
       'include jenkins'
     ]}
 
-    it { should contain_exec('download-myplug').with(:environment => ["http_proxy=proxy.company.com:8080", "https_proxy=proxy.company.com:8080"]) }
+    it do
+      should contain_exec('download-myplug').with(
+        :environment => [
+          "http_proxy=proxy.company.com:8080",
+          "https_proxy=proxy.company.com:8080",
+        ]
+      )
+    end
   end
 
   describe 'with a custom update center' do
@@ -168,6 +181,7 @@ describe 'jenkins::plugin' do
       it 'should download from $source url' do
          should contain_exec('download-myplug').with(
           :command     => 'rm -rf myplug myplug.hpi myplug.jpi && wget --no-check-certificate http://e.org/myplug.hpi',
+          :user        => 'jenkins',
           :cwd         => '/var/lib/jenkins/plugins',
           :environment => nil,
           :path        => ['/usr/bin', '/usr/sbin', '/bin'],


### PR DESCRIPTION
As $plugin_dir has its ownership management, it should always be safe to run the exec resources in this define as the same user.  This eliminates superfluous file permission change notifications from the log output.  E.g.,

    ==> master: Notice: /Stage[main]/Main/Jenkins::Plugin[mailer]/File[/var/lib/jenkins/plugins/mailer.hpi]/owner: owner changed 'root' to 'jenkins'