### PR TITLE
Use jenkins::cli::exec in security.pp

### DIFF
--- a/manifests/security.pp
+++ b/manifests/security.pp
@@ -24,7 +24,7 @@ class jenkins::security (
   include ::jenkins::cli_helper
 
   # XXX not idempotent
-  exec { "jenkins-security-${security_model}":
+  jenkins::cli::exec { "jenkins-security-${security_model}":
     command => [
       'set_security',
       $security_model,


### PR DESCRIPTION
Commit 6bc33de changed a whole bunch of `exec`s to `jenkins::cli::exec`
but missed this one out.

Without this change `exec` gets grumpy about the `command` argument
being an array.