### PR TITLE
Add jenkins::users class to declare all users

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@
 #   config_hash => {
 #     'HTTP_PORT' => { 'value' => '9090' }, 'AJP_PORT' => { 'value' => '9009' }
 #   }
-# V
+# }
 #
 # plugin_hash = undef (Default)
 # Hash with config plugins to install
@@ -80,6 +80,23 @@
 #    'git-client': {}
 #    'token-macro': {}
 #
+#
+# user_hash = {} (Default)
+# Hash with users to create in jenkins
+#
+# Example use
+#
+# class{ 'jenkins':
+#   user_hash => {
+#     'user1' => { 'password' => 'pass1',
+#                     'email' => 'user1@example.com'}
+#
+# Or in Hiera
+#
+# jenkins::user_hash:
+#     'user1':
+#       password: 'pass1'
+#       email: 'user1@example.com'
 #
 # configure_firewall = undef (default)
 #   For folks that want to manage the puppetlabs firewall module.
@@ -133,6 +150,7 @@ class jenkins(
   $config_hash        = {},
   $plugin_hash        = {},
   $job_hash           = {},
+  $user_hash          = {},
   $configure_firewall = undef,
   $install_java       = $jenkins::params::install_java,
   $proxy_host         = undef,
@@ -187,6 +205,7 @@ class jenkins(
   include jenkins::config
   include jenkins::plugins
   include jenkins::jobs
+  include jenkins::users
 
   if $proxy_host and $proxy_port {
     class { 'jenkins::proxy':

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -1,0 +1,11 @@
+# Class: jenkins::users
+#
+class jenkins::users {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
+  create_resources('jenkins::user', $::jenkins::user_hash)
+
+}

--- a/spec/classes/jenkins_users_spec.rb
+++ b/spec/classes/jenkins_users_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'jenkins', :type => :module  do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
+
+  context 'users' do
+    context 'default' do
+      it { should contain_class('jenkins::users') }
+    end
+
+    context 'with testuser' do
+      let(:params) {
+        { :user_hash => { 'user' => {
+          'email' => 'user@example.com',
+          'password' => 'test'
+      } } } }
+      it { should contain_jenkins__user('user').with_email('user@example.com').with_password('test') }
+    end
+
+  end
+
+end


### PR DESCRIPTION
Similar to the jenkins::jobs class that declares all instances of
the jenkins::job defined type, the jenkins::users class declares all
instances of the jenkins::user defined type. I added it to the
main jenkins class with a user_hash parameter.