### PR TITLE
Upgraded puppetlabs-apt version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     apt:
       repo: "git://github.com/puppetlabs/puppetlabs-apt"
-      ref: "1.8.0"
+      ref: "2.1.0"
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
       ref: "4.6.0"

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0 < 5.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 3.0.0" },
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" }


### PR DESCRIPTION
PuppetLabs launched the 2.1.0 branch last month. Although it is a
"major" upgrade, none of the major changes are relevant to this module
(which only takes advantage of the apt::source object type).

This update allows this module to run with either the old and new
version of the apt module, rather than forcing a specific version.

This should resolve #299.