### PR TITLE
Apt upgrade

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     apt:
       repo: "git://github.com/puppetlabs/puppetlabs-apt"
-      ref: "1.8.0"
+      ref: "2.1.0"
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
       ref: "4.6.0"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,6 +162,7 @@ class jenkins(
   $port               = $jenkins::params::port,
   $libdir             = $jenkins::params::libdir,
   $executors          = undef,
+  $apt_version        = $jenkins::params::apt_version,
 ) inherits jenkins::params {
 
   validate_bool($lts, $install_java, $repo)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@ class jenkins::params {
   $cli_try_sleep         = 10
   $package_cache_dir     = '/var/cache/jenkins_pkgs'
   $package_name          = 'jenkins'
-
+  $apt_version           = '1'
   case $::osfamily {
     'Debian': {
       $libdir           = '/usr/share/jenkins'

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -53,15 +53,6 @@ class jenkins::repo::debian(
         include_src => false,
       }
     }
-
-
-
-
-
-
-
-
-
   }
 
   anchor { 'jenkins::repo::debian::begin': } ->

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,6 +1,8 @@
 # Class: jenkins::repo::debian
 #
-class jenkins::repo::debian
+class jenkins::repo::debian(
+
+  )
 {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -10,24 +12,56 @@ class jenkins::repo::debian
   include apt
 
   if $::jenkins::lts  {
-    apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian-stable',
-      release     => 'binary/',
-      repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+    if $::jenkins::apt_version = 2 {
+      apt::source { 'jenkins':
+        location    => 'http://pkg.jenkins-ci.org/debian-stable',
+        release     => 'binary/',
+        repos       => '',
+        key         => {
+          'id' => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+          'source'  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key'
+        }
+      }
+    } else {
+      apt::source { 'jenkins':
+        location    => 'http://pkg.jenkins-ci.org/debian-stable',
+        release     => 'binary/',
+        repos       => '',
+        key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+        include_src => false,
+      }
     }
-  }
-  else {
-    apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian',
-      release     => 'binary/',
-      repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+  } else {
+    if $::jenkins::apt_version = 2 {
+      apt::source { 'jenkins':
+        location    => 'http://pkg.jenkins-ci.org/debian',
+        release     => 'binary/',
+        repos       => '',
+        key         => {
+          'id' => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+          'source'  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+        }
+      }
+    } else {
+      apt::source { 'jenkins':
+        location    => 'http://pkg.jenkins-ci.org/debian',
+        release     => 'binary/',
+        repos       => '',
+        key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+        include_src => false,
+      }
     }
+
+
+
+
+
+
+
+
+
   }
 
   anchor { 'jenkins::repo::debian::begin': } ->

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0 < 5.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 3.0.0" },
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" }


### PR DESCRIPTION
PuppetLabs launched the 2.1.0 branch last month. This update allows this module to run with either the old and new version of the apt module, rather than forcing a specific version.

This is similar to #281, however it also updates the metadata files and provides backwards compatibility.