### PR TITLE
Set no proxy for plugins

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -122,10 +122,14 @@ define jenkins::plugin(
 
   if (empty(grep([ $::jenkins_plugins ], $search))) {
     if ($jenkins::proxy_host) {
+      unless empty($jenkins::no_proxy_list) {
+	      $no_proxy = join($jenkins::no_proxy_list, ',')
+      }
       Exec {
         environment => [
           "http_proxy=${jenkins::proxy_host}:${jenkins::proxy_port}",
-          "https_proxy=${jenkins::proxy_host}:${jenkins::proxy_port}"
+          "https_proxy=${jenkins::proxy_host}:${jenkins::proxy_port}",
+          "no_proxy=${no_proxy}"
         ]
       }
     }

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -103,10 +103,45 @@ describe 'jenkins::plugin' do
     ]}
 
     it do
+      should contain_exec('create-pinnedfile-myplug').with(
+        :environment => [
+          "http_proxy=proxy.company.com:8080",
+          "https_proxy=proxy.company.com:8080",
+          "no_proxy="
+        ]
+      )
       should contain_exec('download-myplug').with(
         :environment => [
           "http_proxy=proxy.company.com:8080",
           "https_proxy=proxy.company.com:8080",
+          "no_proxy="
+        ]
+      )
+    end
+  end
+  
+  describe 'with proxy and no proxy' do
+    let(:pre_condition) { [
+      'class jenkins {
+        $proxy_host = "proxy.company.com"
+        $proxy_port = 8080
+        $no_proxy_list = ["noproxy.company.com", "also-noproxy.com"]
+      }',
+      'include jenkins'
+    ]}
+    it do
+      should contain_exec('create-pinnedfile-myplug').with(
+        :environment => [
+          "http_proxy=proxy.company.com:8080",
+          "https_proxy=proxy.company.com:8080",
+          "no_proxy=noproxy.company.com,also-noproxy.com"
+        ]
+      )
+      should contain_exec('download-myplug').with(
+        :environment => [
+          "http_proxy=proxy.company.com:8080",
+          "https_proxy=proxy.company.com:8080",
+          "no_proxy=noproxy.company.com,also-noproxy.com"
         ]
       )
     end


### PR DESCRIPTION
When downloading plugins proxy is set for http and https but no proxy is not.

This causes issues when wanting to configure the Jenkins proxy details but host plugins internally.