### PR TITLE
Add manage_client_jar option

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -204,6 +204,7 @@ class jenkins::slave (
       comment    => 'Jenkins Slave user',
       home       => $slave_home,
       managehome => $manage_user_home,
+      system     => true,
       uid        => $slave_uid,
     }
   }


### PR DESCRIPTION
Hello,

Please find here two commits.

One is forcing the jenkins to be created as a "system" user.

The second is allowing to disable the download of the .jar file to allow installing it using a system package