### PR TITLE
Update of apt::source to support new version of puppetlabs-apt

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -14,9 +14,10 @@ class jenkins::repo::debian
       location    => 'http://pkg.jenkins-ci.org/debian-stable',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      key         => {
+        id     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key'
+      }
     }
   }
   else {
@@ -24,9 +25,10 @@ class jenkins::repo::debian
       location    => 'http://pkg.jenkins-ci.org/debian',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      key         => {
+        id     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key'
+      }
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0 < 5.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 <3.0.0" },
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" }


### PR DESCRIPTION
This is needed for supporting new puppetlabs-apt module versions.