### PR TITLE
Update jenkins-slave.RedHat init.d script work bash < 4.0

### DIFF
--- a/files/jenkins-slave.RedHat
+++ b/files/jenkins-slave.RedHat
@@ -37,7 +37,7 @@ slave_start() {
 
   # --user in daemon doesn't prepare environment variables like HOME, USER, LOGNAME or USERNAME,
   # so we let su do so for us now
-  $RUNUSER - $JENKINS_SLAVE_USER -c "$JAVA $JAVA_ARGS -jar $JENKINS_SLAVE_JAR $JENKINS_SLAVE_ARGS >> $JENKINS_SLAVE_LOG 2>> $JENKINS_SLAVE_LOG &"
+  $RUNUSER - $JENKINS_SLAVE_USER -c "$JAVA $JAVA_ARGS -jar $JENKINS_SLAVE_JAR $JENKINS_SLAVE_ARGS >> $JENKINS_SLAVE_LOG 2>&1 &"
   pgrep -f -u $JENKINS_SLAVE_USER $JENKINS_SLAVE_JAR > $PIDFILE
   RETVAL=$?
   [ $RETVAL -eq 0 ] && touch $LOCK_FILE

--- a/files/jenkins-slave.RedHat
+++ b/files/jenkins-slave.RedHat
@@ -37,7 +37,7 @@ slave_start() {
 
   # --user in daemon doesn't prepare environment variables like HOME, USER, LOGNAME or USERNAME,
   # so we let su do so for us now
-  $RUNUSER - $JENKINS_SLAVE_USER -c "$JAVA $JAVA_ARGS -jar $JENKINS_SLAVE_JAR $JENKINS_SLAVE_ARGS &>> $JENKINS_SLAVE_LOG &"
+  $RUNUSER - $JENKINS_SLAVE_USER -c "$JAVA $JAVA_ARGS -jar $JENKINS_SLAVE_JAR $JENKINS_SLAVE_ARGS >> $JENKINS_SLAVE_LOG 2>> $JENKINS_SLAVE_LOG &"
   pgrep -f -u $JENKINS_SLAVE_USER $JENKINS_SLAVE_JAR > $PIDFILE
   RETVAL=$?
   [ $RETVAL -eq 0 ] && touch $LOCK_FILE


### PR DESCRIPTION
(First pull request, please be gentle)

Related to issue #225

This change makes the init script work on CentOS-5.x - or really any host using bash less than version 4.0. This is the original error I was receiving:

```
# service jenkins-slave start
Starting Jenkins Slave...
-bash: -c: line 0: syntax error near unexpected token `>'
-bash: -c: line 0: `/usr/bin/java  -jar /home/jenkins-slave/swarm-client-1.22-jar-with-dependencies.jar -mode normal -executors 1  -name <redacted> -master <redacted> -labels '<redacted>' -fsroot '/home/jenkins-slave'  &>> /var/log/jenkins-slave/jenkins-slave.log &'
```

This change is more portable than the original command line. So even if this project doesn't want to support CentOS-5.x, this change still guards against shell "gotchas" like this.