### PR TITLE
Systemd

### DIFF
--- a/files/jenkins-slave.systemd
+++ b/files/jenkins-slave.systemd
@@ -1,0 +1,29 @@
+# It's not recommended to modify this file in-place, because it will be
+# overwritten during package upgrades.  If you want to customize, the best
+# way is to create a file "/etc/systemd/system/httpd.service",
+# containing
+#   .include /lib/systemd/system/httpd.service
+#   ...make your changes here...
+# For more info about custom unit files, see
+# http://fedoraproject.org/wiki/Systemd#How_do_I_customize_a_unit_file.2F_add_a_custom_unit_file.3F
+
+# For example, to pass additional options (for instance, -D definitions) to the
+# httpd binary at startup, you need to create a file named
+# "/etc/systemd/system/httpd.service" containing:
+#	.include /lib/systemd/system/httpd.service
+#	[Service]
+#	Environment=OPTIONS=-DMY_DEFINE
+
+[Unit]
+Description=Jenkins slave
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/etc/init.d/jenkins-slave start
+ExecStop=/etc/init.d/jenkins-slave stop
+ExecReload=/etc/init.d/jenkins-slave restart
+
+[Install]
+WantedBy=multi-user.target

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class jenkins::params {
   $service_enable        = true
   $service_ensure        = 'running'
   $install_java          = true
-  $swarm_version         = '1.22'
+  $swarm_version         = '1.24'
   $default_plugins_host  = 'http://updates.jenkins-ci.org'
   $port                  = '8080'
   $cli_tries             = 10

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -141,6 +141,14 @@ class jenkins::slave (
         before => Service['jenkins-slave'],
       }
     }
+    'RedHat': {
+      file { '/etc/systemd/system/jenkins-slave.service':
+        owner => 'root',
+        group => 'root',
+        before => Service['jenkins-slave'],
+        source => "puppet:///modules/${module_name}/jenkins-slave.systemd",
+      }
+    }
     default: {
       $defaults_location = '/etc/sysconfig'
     }


### PR DESCRIPTION
This commit adds support for systemd based distros and upgrades swarm to 1.24 version - is there any reason to stay with older one ? Tested on Fedora21 and Centos7.1.
