### PR TITLE
Upgraded apt module dependency to support v2

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     apt:
       repo: "git://github.com/puppetlabs/puppetlabs-apt"
-      ref: "1.8.0"
+      ref: "2.1.0"
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
       ref: "4.6.0"

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0 < 5.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 2.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 3.0.0" },
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" }


### PR DESCRIPTION
This supersedes #301.

When they released the v2.0 version of the apt module, the folks at Pupperlabs also broke backwards compatibility. This caused a lot of problems, so they've gone back and released a v2.1 that adds support for the v1 way of doing things.

What this means is that it's better so support the old way of doing things than the new way, as the old way has the largest compatibility spread. In my previous pull request (which was made before the apt v2.1 release was made) I attempted to support both version of the module, but this accomplishes that much better.

There is one caveat though- this module will not support v2.0 of the apt module, and unfortunately there is no way to exclude specific versions of dependencies in the metadata.json file. This means there's no way to prevent this module from being installed next to an incompatible module, but I think that's a reasonable decision to make since this module otherwise won't be usable with any of the v2 line at all.