### PR TITLE
Support configuring a yum proxy server

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,6 +125,8 @@
 # cli_try_sleep = 10 (default)
 #   Seconds between tries to contact jenkins API
 #
+# yum_proxy = undef (default)
+#   If you environment requires a proxy to download yum packages
 #
 # proxy_host = undef (default)
 # proxy_port = undef (default)
@@ -153,6 +155,7 @@ class jenkins(
   $user_hash          = {},
   $configure_firewall = undef,
   $install_java       = $jenkins::params::install_java,
+  $yum_proxy          = undef,
   $proxy_host         = undef,
   $proxy_port         = undef,
   $no_proxy_list      = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,8 +125,8 @@
 # cli_try_sleep = 10 (default)
 #   Seconds between tries to contact jenkins API
 #
-# yum_proxy = undef (default)
-#   If you environment requires a proxy to download yum packages
+# repo_proxy = undef (default)
+#   If you environment requires a proxy to download packages
 #
 # proxy_host = undef (default)
 # proxy_port = undef (default)
@@ -155,7 +155,7 @@ class jenkins(
   $user_hash          = {},
   $configure_firewall = undef,
   $install_java       = $jenkins::params::install_java,
-  $yum_proxy          = undef,
+  $repo_proxy         = undef,
   $proxy_host         = undef,
   $proxy_port         = undef,
   $no_proxy_list      = undef,

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -7,6 +7,8 @@ class jenkins::repo::el
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  $yum_proxy = $::jenkins::yum_proxy
+
   if $::jenkins::lts  {
     yumrepo {'jenkins':
       descr    => 'Jenkins',
@@ -26,4 +28,11 @@ class jenkins::repo::el
       enabled  => 1,
     }
   }
+
+  if $yum_proxy {
+    Yumrepo['jenkins'] {
+      proxy => $yum_proxy,
+    }
+  }
+
 }

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -16,6 +16,7 @@ class jenkins::repo::el
       gpgcheck => 1,
       gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
       enabled  => 1,
+      proxy    => $repo_proxy
     }
   }
 
@@ -26,13 +27,7 @@ class jenkins::repo::el
       gpgcheck => 1,
       gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
       enabled  => 1,
+      proxy    => $repo_proxy
     }
   }
-
-  if $yum_proxy {
-    Yumrepo['jenkins'] {
-      proxy => $yum_proxy,
-    }
-  }
-
 }

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -7,7 +7,7 @@ class jenkins::repo::el
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  $yum_proxy = $::jenkins::yum_proxy
+  $repo_proxy = $::jenkins::repo_proxy
 
   if $::jenkins::lts  {
     yumrepo {'jenkins':

--- a/spec/classes/jenkins_repo_el_spec.rb
+++ b/spec/classes/jenkins_repo_el_spec.rb
@@ -16,8 +16,8 @@ describe 'jenkins', :type => :module do
       it { should contain_yumrepo('jenkins').with_proxy(nil) }
     end
 
-    describe 'yumproxy is set' do
-      let(:params) { { :yum_proxy => 'http://proxy:8080/' }}
+    describe 'repo_proxy is set' do
+      let(:params) { { :repo_proxy => 'http://proxy:8080/' }}
       it { should contain_yumrepo('jenkins').with_proxy('http://proxy:8080/') }
     end
   end

--- a/spec/classes/jenkins_repo_el_spec.rb
+++ b/spec/classes/jenkins_repo_el_spec.rb
@@ -7,11 +7,18 @@ describe 'jenkins', :type => :module do
   context 'repo::el' do
     describe 'default' do
       it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat/') }
+      it { should contain_yumrepo('jenkins').with_proxy(nil) }
     end
 
     describe 'lts = true' do
       let(:params) { { :lts => true } }
       it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat-stable/') }
+      it { should contain_yumrepo('jenkins').with_proxy(nil) }
+    end
+
+    describe 'yumproxy is set' do
+      let(:params) { { :yum_proxy => 'http://proxy:8080/' }}
+      it { should contain_yumrepo('jenkins').with_proxy('http://proxy:8080/') }
     end
   end
 


### PR DESCRIPTION
This pull request adds a new parameter yum_proxy to init.pp. It's used in repo/el.pp to configure the jenkins yum repository with a proxy server. 

This allows installing jenkins via yum behind a proxy server.