### PR TITLE
Fix jenkins::plugin with create_user false

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -56,21 +56,26 @@ define jenkins::plugin(
 
   if (!defined(File[$plugin_dir])) {
     if (!defined(File[$plugin_parent_dir])) {
-      file { $plugin_parent_dir:
-        ensure  => directory,
-        owner   => $username,
-        group   => $group,
-        mode    => '0755',
-        require => [Group[$group], User[$username]],
+      # ensure ownership only when it's home directory for the new user
+      if $create_user {
+        file { $plugin_parent_dir:
+          ensure => directory,
+          owner  => $username,
+          group  => $group,
+          mode   => '0755',
+        }
+      } else {
+        file { $plugin_parent_dir:
+          ensure => directory,
+        }
       }
     }
 
     file { $plugin_dir:
-      ensure  => directory,
-      owner   => $username,
-      group   => $group,
-      mode    => '0755',
-      require => [Group[$group], User[$username]],
+      ensure => directory,
+      owner  => $username,
+      group  => $group,
+      mode   => '0755',
     }
 
   }
@@ -89,6 +94,8 @@ define jenkins::plugin(
         require => Package[$::jenkins::package_name],
       }
     }
+    User[$username] -> File[$plugin_dir]
+    Group[$group] -> File[$plugin_dir]
   }
 
   if (!defined(Package['wget'])) {


### PR DESCRIPTION
We have setup with jenkins running under tomcat (user tomcat7), but still it is good idea to have Jenkins files in /var/lib/jenkins.

This patch fixes plugin installation in this use-case - with external user already created and also when it is different from /var/lib/jenkins owner.

(this is fixed pull request #333)