### PR TITLE
Allow setup LDAP auth

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -26,6 +26,8 @@ import com.cloudbees.plugins.credentials.impl.*
 import com.cloudbees.plugins.credentials.impl.*;
 import hudson.plugins.sshslaves.*;
 import jenkins.model.*;
+import jenkins.security.*;
+import hudson.security.*;
 import hudson.model.*;
 
 class InvalidAuthenticationStrategy extends Exception{}


### PR DESCRIPTION
Be able to setup LDAP auth on Jenkins master. This resulted in splitting
set security method into three methods for setting:
- ldap auth
- password auth
- unsecured

Also give choice to turn on the slave to master feature during
deployment.
