### PR TITLE
(RFC - not ready for merge) use camptocamp/archive for all downloads

### DIFF
--- a/manifests/direct_download.pp
+++ b/manifests/direct_download.pp
@@ -25,11 +25,24 @@ class jenkins::direct_download {
   validate_absolute_path($local_file)
 
   if $::jenkins::version != 'absent' {
+    $enable_checksum = $::jenkins::direct_download_checksum ? {
+      undef   => false,
+      default => true,
+    }
+
     # make download optional if we are removing...
-    staging::file { $package_file:
-      source => $jenkins::direct_download,
-      target => $local_file,
-      before => Package[$::jenkins::package_name],
+    archive::download { $package_file:
+      url              => $::jenkins::direct_download,
+      src_target       => $::jenkins::package_cache_dir,
+      allow_insecure   => true,
+      follow_redirects => true,
+      checksum         => $enable_checksum,
+      digest_string    => $::jenkins::direct_download_checksum,
+      digest_type      => $::jenkins::direct_download_checksum_type,
+      proxy_server     => $::jenkins::http_proxy,
+      verbose          => false,
+      require          => File[$::jenkins::package_cache_dir],
+      before           => Package[$::jenkins::package_name],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,31 +140,33 @@
 #
 #
 class jenkins(
-  $version            = $jenkins::params::version,
-  $lts                = $jenkins::params::lts,
-  $repo               = $jenkins::params::repo,
-  $package_name       = $jenkins::params::package_name,
-  $direct_download    = false,
-  $package_cache_dir  = $jenkins::params::package_cache_dir,
-  $package_provider   = $jenkins::params::package_provider,
-  $service_enable     = $jenkins::params::service_enable,
-  $service_ensure     = $jenkins::params::service_ensure,
-  $config_hash        = {},
-  $plugin_hash        = {},
-  $job_hash           = {},
-  $user_hash          = {},
-  $configure_firewall = undef,
-  $install_java       = $jenkins::params::install_java,
-  $repo_proxy         = undef,
-  $proxy_host         = undef,
-  $proxy_port         = undef,
-  $no_proxy_list      = undef,
-  $cli                = undef,
-  $cli_tries          = $jenkins::params::cli_tries,
-  $cli_try_sleep      = $jenkins::params::cli_try_sleep,
-  $port               = $jenkins::params::port,
-  $libdir             = $jenkins::params::libdir,
-  $executors          = undef,
+  $version                       = $jenkins::params::version,
+  $lts                           = $jenkins::params::lts,
+  $repo                          = $jenkins::params::repo,
+  $package_name                  = $jenkins::params::package_name,
+  $direct_download               = false,
+  $direct_download_checksum      = undef,
+  $direct_download_checksum_type = 'sha1',
+  $package_cache_dir             = $jenkins::params::package_cache_dir,
+  $package_provider              = $jenkins::params::package_provider,
+  $service_enable                = $jenkins::params::service_enable,
+  $service_ensure                = $jenkins::params::service_ensure,
+  $config_hash                   = {},
+  $plugin_hash                   = {},
+  $job_hash                      = {},
+  $user_hash                     = {},
+  $configure_firewall            = undef,
+  $install_java                  = $jenkins::params::install_java,
+  $repo_proxy                    = undef,
+  $proxy_host                    = undef,
+  $proxy_port                    = undef,
+  $no_proxy_list                 = undef,
+  $cli                           = undef,
+  $cli_tries                     = $jenkins::params::cli_tries,
+  $cli_try_sleep                 = $jenkins::params::cli_try_sleep,
+  $port                          = $jenkins::params::port,
+  $libdir                        = $jenkins::params::libdir,
+  $executors                     = undef,
 ) inherits jenkins::params {
 
   validate_bool($lts, $install_java, $repo)
@@ -180,6 +182,12 @@ class jenkins(
 
   if $executors {
     validate_integer($executors)
+  }
+
+  if ($jenkins::proxy_host) {
+    $http_proxy = "http://${jenkins::proxy_host}:${jenkins::proxy_port}/"
+  } else {
+    $http_proxy = undef
   }
 
   anchor {'jenkins::begin':}
@@ -204,6 +212,9 @@ class jenkins(
     }
   }
   include $jenkins_package_class
+
+  validate_string($direct_download_checksum)
+  validate_string($direct_download_checksum_type)
 
   include jenkins::config
   include jenkins::plugins

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,6 @@
     { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 3.0.0" },
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
-    { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" },
-    { "name": "camptocamp/archive", "version_requirement": ">= 0.8.0" }
+    { "name": "camptocamp/archive", "version_requirement": ">= 0.8.0 < 1.0.0" }
   ]
 }


### PR DESCRIPTION
Replaces direct usage of wget from exec and nanliu/staging.  Intended to be an
interim solution until nanliu/archive gains proxy support.