### PR TITLE
Parameterises the Java package name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,9 @@
 #   - use puppetlabs-java module to install the correct version of a JDK.
 #   - Jenkins requires a JRE
 #
+# java_package_name = undef (default)
+#   - choose the name of the package to install with puppetlabs-java if the if install_java parameter is true
+#   - defaults to undef, which will use the default taken from the puppetlabs-java module from the params
 #
 # cli = false (default)
 #   - force installation of the jenkins CLI jar to $libdir/cli/jenkins-cli.jar
@@ -155,6 +158,7 @@ class jenkins(
   $user_hash          = {},
   $configure_firewall = undef,
   $install_java       = $jenkins::params::install_java,
+  $java_package_name  = undef,
   $repo_proxy         = undef,
   $proxy_host         = undef,
   $proxy_port         = undef,
@@ -187,7 +191,8 @@ class jenkins(
 
   if $install_java {
     class {'java':
-      distribution => 'jdk'
+      distribution  => 'jdk',
+      name          => $java_package_name,
     }
   }
 

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -33,6 +33,11 @@ describe 'jenkins', :type => :module do
       it { should_not contain_class 'jenkins::repo' }
     end
 
+    describe 'with java_package_name' do
+      let(:params) { { :java_package_name => 'java-1.7.0-openjdk.x86_64' } }
+      it { should contain_class('java').with({'name' => 'java-1.7.0-openjdk.x86_64'}) }
+    end
+
     describe 'with only proxy host' do
       let(:params) { { :proxy_host => '1.2.3.4' } }
       it { should_not contain_class('jenkins::proxy') }


### PR DESCRIPTION
On CentOS 5, the Puppetlabs Java module defaults to Java 1.6

However, this will break Jenkins:

```
/usr/bin/java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://127.0.0.1:8080 groovy /usr/lib/jenkins/puppet_helper.groovy set_num_executors 42
Exception in thread "main" java.lang.UnsupportedClassVersionError: hudson/cli/CLI : Unsupported major.minor version 51.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:643)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:277)
	at java.net.URLClassLoader.access$000(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:212)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:205)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:323)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:294)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:268)
Could not find the main class: hudson.cli.CLI. Program will exit.
```

So you have to tell it to install java-1.7.0-openjdk.x86_64 for Java.