### PR TITLE
Fix require paths

### DIFF
--- a/lib/facter/jenkins.rb
+++ b/lib/facter/jenkins.rb
@@ -4,7 +4,7 @@
 # jenkins plugins + versions.
 #
 #
-require 'puppet/jenkins/facts'
+require File.join(File.dirname(__FILE__), '..', 'puppet/jenkins/facts.rb')
 
 # If we're being loaded inside the module, we'll need to go ahead and add our
 # facts then won't we?

--- a/lib/puppet/jenkins/facts.rb
+++ b/lib/puppet/jenkins/facts.rb
@@ -1,6 +1,6 @@
 require 'facter'
-require 'puppet/jenkins'
-require 'puppet/jenkins/plugins'
+require File.join(File.dirname(__FILE__), '..', 'jenkins.rb')
+require File.join(File.dirname(__FILE__), '..', 'jenkins/plugins.rb')
 
 module Puppet
   module Jenkins

--- a/lib/puppet/jenkins/plugins.rb
+++ b/lib/puppet/jenkins/plugins.rb
@@ -1,4 +1,4 @@
-require 'puppet/jenkins'
+require File.join(File.dirname(__FILE__), '..', 'jenkins.rb')
 
 module Puppet
   module Jenkins


### PR DESCRIPTION
This fixes the `require` paths on Ruby 1.8.7 with Puppet 2.7. See issue #132.