### PR TITLE
Added funtionality to run the define jenkins::job::present as the jenkins user

### DIFF
--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -35,6 +35,7 @@ define jenkins::job::present(
 
   Exec {
     logoutput   => false,
+    user        => 'jenkins',
     path        => '/bin:/usr/bin:/sbin:/usr/sbin',
     tries       => $cli_tries,
     try_sleep   => $cli_try_sleep,


### PR DESCRIPTION
Just a small change so the define jenkins::job::present as the jenkins user. We ran into issues once we applied full security that Puppet was not able to add jobs. 