### PR TITLE
add darwin/osx support to slave class

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -126,15 +126,6 @@ class jenkins::slave (
     }
   }
 
-  exec { 'get_swarm_client':
-    command => "wget -O ${slave_home}/${client_jar} ${client_url}/${client_jar}",
-    path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-    user    => $slave_user,
-  #refreshonly => true,
-    creates => "${slave_home}/${client_jar}",
-  ## needs to be fixed if you create another version..
-  }
-
 # customizations based on the OS family
   case $::osfamily {
     'Debian': {
@@ -145,31 +136,87 @@ class jenkins::slave (
         before => Service['jenkins-slave'],
       }
     }
+    'Darwin': {
+      $defaults_location = $slave_home
+    }
     default: {
       $defaults_location = '/etc/sysconfig'
     }
   }
 
-  file { '/etc/init.d/jenkins-slave':
-    ensure => 'file',
-    mode   => '0755',
-    owner  => 'root',
-    group  => 'root',
-    source => "puppet:///modules/${module_name}/jenkins-slave.${::osfamily}",
-    notify => Service['jenkins-slave'],
+  case $::kernel {
+    'Linux': {
+      $fetch_command  = "wget -O ${slave_home}/${client_jar} ${client_url}/${client_jar}"
+      $service_name   = 'jenkins-slave'
+      $defaults_user  = 'root'
+      $defaults_group = 'root'
+
+      file { '/etc/init.d/jenkins-slave':
+        ensure => 'file',
+        mode   => '0755',
+        owner  => 'root',
+        group  => 'root',
+        source => "puppet:///modules/${module_name}/jenkins-slave.${::osfamily}",
+        notify => Service['jenkins-slave'],
+      }
+    }
+    'Darwin': {
+      $fetch_command  = "curl -O ${client_url}/${client_jar}"
+      $service_name   = 'org.jenkins-ci.slave.jnlp'
+      $defaults_user  = 'jenkins'
+      $defaults_group = 'wheel'
+
+      file { "${slave_home}/start-slave.sh":
+        ensure  => 'file',
+        content => template("${module_name}/start-slave.sh.erb"),
+        mode    => '0755',
+        owner   => 'root',
+        group   => 'wheel',
+      }
+
+      file { '/Library/LaunchDaemons/org.jenkins-ci.slave.jnlp.plist':
+        ensure  => 'file',
+        content => template("${module_name}/org.jenkins-ci.slave.jnlp.plist.erb"),
+        mode    => '06444',
+        owner   => 'root',
+        group   => 'wheel',
+      }
+
+      file { '/var/log/jenkins':
+        ensure => 'directory',
+        owner  => $slave_user,
+        group  => $slave_group,
+      }
+
+      File['/var/log/jenkins'] ->
+        File['/Library/LaunchDaemons/org.jenkins-ci.slave.jnlp.plist'] ->
+          Service['jenkins-slave']
+    }
+    default: { }
   }
 
   file { "${defaults_location}/jenkins-slave":
     ensure  => 'file',
     mode    => '0600',
-    owner   => 'root',
-    group   => 'root',
+    owner   => $defaults_user,
+    group   => $defaults_group,
     content => template("${module_name}/jenkins-slave-defaults.erb"),
     notify  => Service['jenkins-slave'],
   }
 
+  exec { 'get_swarm_client':
+    command    => $fetch_command,
+    path       => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+    user       => $slave_user,
+    #refreshonly => true,
+    creates    => "${slave_home}/${client_jar}",
+    cwd        => $slave_home,
+  ## needs to be fixed if you create another version..
+  }
+
   service { 'jenkins-slave':
     ensure     => $ensure,
+    name       => $service_name,
     enable     => $enable,
     hasstatus  => true,
     hasrestart => true,

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -4,7 +4,7 @@ describe 'jenkins::slave' do
 
   shared_context 'a jenkins::slave catalog' do
     it { should contain_exec('get_swarm_client') }
-    it { should contain_file('/etc/init.d/jenkins-slave') }
+    it { should contain_file(slave_service_file) }
     it { should contain_service('jenkins-slave').with(:enable => true, :ensure => 'running') }
     it { should contain_user('jenkins-slave_user').with_uid(nil) }
     # Let the different platform blocks define  `slave_runtime_file` separately below
@@ -44,9 +44,9 @@ describe 'jenkins::slave' do
   end
 
   describe 'RedHat' do
-    let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'CentOS' } }
+    let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'CentOS', :kernel => 'Linux' } }
     let(:slave_runtime_file) { '/etc/sysconfig/jenkins-slave' }
-
+    let(:slave_service_file) { '/etc/init.d/jenkins-slave' }
     it_behaves_like 'a jenkins::slave catalog'
 
     describe 'with slave_name' do
@@ -56,8 +56,9 @@ describe 'jenkins::slave' do
   end
 
   describe 'Debian' do
-    let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'debian', :lsbdistcodename => 'natty', :operatingsystem => 'Debian' } }
+    let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'debian', :lsbdistcodename => 'natty', :operatingsystem => 'Debian', :kernel => 'Linux' } }
     let(:slave_runtime_file) { '/etc/default/jenkins-slave' }
+    let(:slave_service_file) { '/etc/init.d/jenkins-slave' }
 
     it_behaves_like 'a jenkins::slave catalog'
 
@@ -66,6 +67,19 @@ describe 'jenkins::slave' do
       it_behaves_like 'using slave_name'
     end
   end
+
+#  describe 'Darwin' do
+#    let(:facts) { { :osfamily => 'Darwin', :operatingsystem => 'Darwin', :kernel => 'Darwin' } }
+#    let(:slave_runtime_file) { '/home/jenkins-slave/jenkins-slave' }
+#    let(:slave_service_file) { '/Library/LaunchDaemons/org.jenkins-ci.slave.jnlp.plist' }
+#
+#    it_behaves_like 'a jenkins::slave catalog'
+#
+#    describe 'with slave_name' do
+#      let(:params) { { :slave_name => 'jenkins-slave' } }
+#      it_behaves_like 'using slave_name'
+#    end
+#  end
 
   describe 'Unknown' do
     let(:facts) { { :ostype => 'Unknown' } }

--- a/templates/org.jenkins-ci.slave.jnlp.plist.erb
+++ b/templates/org.jenkins-ci.slave.jnlp.plist.erb
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-/Apple/DTD PLIST 1.0/EN" "http:/www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.jenkins-ci.slave.jnlp</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string><%= @slave_home %>/start-slave.sh</string>
+  </array>
+  <key>KeepAlive</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>UserName</key>
+  <string><%= @slave_user %></string>
+  <key>WorkingDirectory</key>
+  <string><%= @slave_home %></string>
+  <key>SessionCreate</key>
+  <true/>
+  <key>StandardInPath</key>
+  <string>/dev/null</string>
+  <key>StandardErrorPath</key>
+  <string>/var/log/jenkins/org.jenkins-ci.slave.jnlp.log</string>
+  <key>StandardOutPath</key>
+  <string>/var/log/jenkins/org.jenkins-ci.slave.jnlp.log</string>
+</dict>
+</plist>

--- a/templates/start-slave.sh.erb
+++ b/templates/start-slave.sh.erb
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source <%= @defaults_location %>/jenkins-slave 
+java -jar <%= @slave_home %>/<%= @client_jar %> $JENKINS_SLAVE_ARGS


### PR DESCRIPTION
This utilizes the existing defaults file, along with a wrapper script and launchd service. There is no wget by default on OSX so use curl there (could be used everywhere, or instead use a puppet module such as archive).