### PR TITLE
Adding cli_ssh_keyfile parameter to specify the location of a private key

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -28,8 +28,23 @@ class jenkins::cli {
 
   $port = jenkins_port()
 
+  # Provide the -i flag if specified by the user.
+  if $::jenkins::cli_ssh_keyfile {
+    $auth_arg = "-i ${::jenkins::cli_ssh_keyfile}"
+  } else {
+    $auth_arg = undef
+  }
+
   # The jenkins cli command with required parameter(s)
-  $cmd = "java -jar ${jar} -s http://localhost:${port}"
+  $cmd = join(
+    delete_undef_values([
+      'java',
+      "-jar ${::jenkins::cli::jar}",
+      "-s http://localhost:${port}",
+      $auth_arg,
+    ]),
+    ' '
+  )
 
   # Do a safe restart of Jenkins (only when notified)
   exec { 'safe-restart-jenkins':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,6 +118,11 @@
 #   - CLI installation (both implicit and explicit) requires the unzip command
 #
 #
+# cli_ssh_keyfile = undef (default)
+#   Provides the location of an ssh private key file to make authenticated
+#   connections to the Jenkins CLI.
+#
+#
 # cli_tries = 10 (default)
 #   Retries until giving up talking to jenkins API
 #
@@ -160,6 +165,7 @@ class jenkins(
   $proxy_port         = undef,
   $no_proxy_list      = undef,
   $cli                = undef,
+  $cli_ssh_keyfile    = undef,
   $cli_tries          = $jenkins::params::cli_tries,
   $cli_try_sleep      = $jenkins::params::cli_try_sleep,
   $port               = $jenkins::params::port,

--- a/spec/classes/jenkins_cli_spec.rb
+++ b/spec/classes/jenkins_cli_spec.rb
@@ -10,11 +10,13 @@ describe 'jenkins', :type => :module do
 
     context '$cli => true' do
       let(:params) {{ :cli => true,
+                      :cli_ssh_keyfile => '/path/to/key',
                       :config_hash => { 'HTTP_PORT' => { 'value' => '9000' } }
       }}
       it { should create_class('jenkins::cli') }
       it { should contain_exec('jenkins-cli') }
       it { should contain_exec('reload-jenkins').with_command(/http:\/\/localhost:9000/) }
+      it { should contain_exec('reload-jenkins').with_command(/-i\s\/path\/to\/key/) }
       it { should contain_exec('safe-restart-jenkins') }
       it { should contain_jenkins__sysconfig('HTTP_PORT').with_value('9000') }
     end


### PR DESCRIPTION
Greetings! This patch allows the user to specify a key when issuing cli commands. This will prevent things like jenkins::cli::reload from being run as the anonymous user, which breaks if you want to use a restrictive permission scheme.

This might also solve https://github.com/jenkinsci/puppet-jenkins/issues/259.