### PR TITLE
Class cannot find exec in jenkins::cli::reload.

### DIFF
--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -19,6 +19,7 @@ define jenkins::job::present(
   $enabled  = 1,
 ){
   include jenkins::cli
+  include jenkins::cli::reload
 
   if $jenkins::service_ensure == 'stopped' or $jenkins::service_ensure == false {
     fail('Management of Jenkins jobs requires \$jenkins::service_ensure to be set to \'running\'')


### PR DESCRIPTION
The class jenkins::job:present is not able to find the class jenkins::cli::reload to run the reload-jenkins exec when using a  pre-built config file in a jenkins::job_hash.