### PR TITLE
Make the jenkins system user and group OS dependent. 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,14 +18,20 @@ class jenkins::params {
 
   case $::osfamily {
     'Debian': {
+      $jenkins_user       = 'jenkins'
+      $jenkins_group      = 'jenkins'
       $libdir           = '/usr/share/jenkins'
       $package_provider = 'dpkg'
     }
     'RedHat': {
+      $jenkins_user       = 'jenkins'
+      $jenkins_group      = 'jenkins'
       $libdir           = '/usr/lib/jenkins'
       $package_provider = 'rpm'
     }
     default: {
+      $jenkins_user       = 'jenkins'
+      $jenkins_group      = 'jenkins'
       $libdir = '/usr/lib/jenkins'
       $package_provider = false
     }

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -12,8 +12,8 @@ class jenkins::proxy {
 
   file { '/var/lib/jenkins/proxy.xml':
     content => template('jenkins/proxy.xml.erb'),
-    owner   => 'jenkins',
-    group   => 'jenkins',
+    owner   => $::jenkins::params::jenkins_user,
+    group   => $::jenkins::params::jenkins_group,
     mode    => '0644'
   }
 

--- a/spec/classes/jenkins_master_spec.rb
+++ b/spec/classes/jenkins_master_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'jenkins::master' do
 
   let(:params) { { :version => '1.2.3' } }
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
   it { should contain_jenkins__plugin('swarm').with_version('1.2.3') }
 
 end

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'jenkins::plugin' do
+  let(:facts) { { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } }
   let(:title) { 'myplug' }
 
   shared_examples 'manages plugins dirs' do


### PR DESCRIPTION
Default values are set in and picked up from params.pp.

The two new parameters are:
  jenkins_user
  jenkins_group

The specs for the proxy class, and the plugin define added facts
to pin it to osfamily/operatingsystem RedHat, in order to let
them work in the future, when there may be other OS with different
users/groups out there.

I haven't made the jenkins_user/jenkins_group overridable as
parameter to init.pp, since I found that not all parameters defined
in params.pp are able to be overridden.

This is a follow up of PR #304 , splitting parts off the whole PR.
