### PR TITLE
Add template in the jenkins::job

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -11,6 +11,10 @@
 #     path to a puppet file() resource containing the Jenkins XML job description
 #     will override 'config' if set
 #
+#   template
+#     path to a puppet template() resource containing the Jenkins XML job description
+#     will override 'config' if set
+#
 #   jobname = $title
 #     the name of the jenkins job
 #
@@ -23,6 +27,7 @@
 define jenkins::job(
   $config,
   $source   = undef,
+  $template = undef,
   $jobname  = $title,
   $enabled  = 1,
   $ensure   = 'present',
@@ -41,6 +46,10 @@ define jenkins::job(
     if $source {
       validate_string($source)
       $realconfig = file($source)
+    }
+    elsif $template {
+      validate_string($template)
+      $realconfig = template($template)
     }
     else {
       $realconfig = $config

--- a/spec/defines/jenkins_job_spec.rb
+++ b/spec/defines/jenkins_job_spec.rb
@@ -127,4 +127,25 @@ eos
     it { should raise_error(Puppet::Error, /Must pass config/) }
   end
 
+  describe 'with templated config and blank regular config' do
+    let(:thetemplate) { File.expand_path(File.dirname(__FILE__) + '/../fixtures/testjob.xml') }
+    let(:params) {{ :ensure => 'present', :template => thetemplate, :config => '' }}
+    it { should contain_file('/tmp/myjob-config.xml')\
+      .with_content(/sourcedconfig/) }
+  end
+
+  describe 'with templated config and regular config' do
+    quotes = "<xml version='1.0' encoding='UTF-8'></xml>"
+    let(:thetemplate) { File.expand_path(File.dirname(__FILE__) + '/../fixtures/testjob.xml') }
+    let(:params) {{ :ensure => 'present', :template => thetemplate, :config => quotes }}
+    it { should contain_file('/tmp/myjob-config.xml')\
+      .with_content(/sourcedconfig/) }
+  end
+
+  describe 'with templated config and no regular config' do
+    let(:thetemplate) { File.expand_path(File.dirname(__FILE__) + '/../fixtures/testjob.xml') }
+    let(:params) {{ :ensure => 'present', :template => thetemplate }}
+    it { should raise_error(Puppet::Error, /Must pass config/) }
+  end
+
 end


### PR DESCRIPTION
I propose this improvement to add an option to avoid copy/paste files.

Very helpfull when we use something like:
```puppet
  $jobs = hiera('jenkins::jobs')
  create_resources(jenkins::job, $jobs)
```

And a hiera like this one:
```yaml
jenkins::jobs :
  petclinic-build:
    jobname: 'petclinic-build'
    config: ''
    source: 'g10b/petclinic-build.xml'
```