### PR TITLE
Making the management of the daemon package optional

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -92,7 +92,8 @@ class jenkins::slave (
   $tool_locations           = undef,
   $install_java             = $jenkins::params::install_java,
   $ensure                   = 'running',
-  $enable                   = true
+  $enable                   = true,
+  $manage_packages          = true,
 ) inherits jenkins::params {
 
   $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"
@@ -110,10 +111,11 @@ class jenkins::slave (
   case $::osfamily {
     'Debian': {
       $defaults_location = '/etc/default'
-
-      package { 'daemon':
-        ensure => present,
-        before => Service['jenkins-slave'],
+      if $manage_packages {
+        package { 'daemon':
+          ensure => present,
+          before => Service['jenkins-slave'],
+        }
       }
     }
     'Darwin': {


### PR DESCRIPTION
This tripped up my team. Perhaps a bit of an overkill fix, but at least it retains existing functionality. I'd love to hear of a different approach if you have something you'd suggest.