### PR TITLE
fix rspec-puppet `raise_error` warning

### DIFF
--- a/spec/classes/jenkins_direct_download_spec.rb
+++ b/spec/classes/jenkins_direct_download_spec.rb
@@ -34,7 +34,7 @@ describe 'jenkins', :type => :module do
     context 'unsupported provider fails' do
       let (:params) { { :package_provider => false, :direct_download => 'http://local.space/jenkins.rpm' } }
       it do
-        expect { should compile }.to raise_error
+        expect { should compile }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /error during compilation/)
       end
     end
   end

--- a/spec/classes/jenkins_jobs_spec.rb
+++ b/spec/classes/jenkins_jobs_spec.rb
@@ -17,7 +17,9 @@ describe 'jenkins', :type => :module  do
       let(:params) { { :service_ensure => 'stopped',
                        :cli => false,
                        :job_hash => { 'build' => { 'config' => '<xml/>' } } } }
-      it { expect { should compile }.to raise_error }
+      it do
+        expect { should compile }.to raise_error(RSpec::Expectations::ExpectationNotMetError, /error during compilation/)
+      end
     end
 
   end


### PR DESCRIPTION
Resolves this warning:

    WARNING: Using the `raise_error` matcher without providing a specific
    error or message risks false positives, since `raise_error` will match
    when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
    potentially allowing the expectation to pass without even executing the
    method you are intending to call. Instead consider providing a specific
    error class or message. This message can be supressed by setting:
    `RSpec::Expectations.configuration.warn_about_potential_false_positives
    = false`.