### PR TITLE
(RFC) native types and providers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ group :development do
   gem 'debugger', :platform => :mri_19
   gem 'debugger-pry', :platform => :mri_19
   gem 'byebug', :platform => [:mri_20, :mri_21]
+  gem 'pry'
+  gem 'pry-byebug'
 end
 
 group :system_tests do

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'puppet-syntax', '>= 1.1.0'
 gem 'json'
 gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.5'
 gem 'metadata-json-lint'
+gem 'retries', '~> 0.0.5'
 
 group :development do
   gem 'simplecov'

--- a/NATIVE_TYPES_AND_PROVIDERS.md
+++ b/NATIVE_TYPES_AND_PROVIDERS.md
@@ -1,0 +1,385 @@
+Experimental native types and providers
+==
+
+This family of types and providers that manages jenkins via the `cli` jar take
+common configuration from the parameters of a class named
+`jenkins::cli::config`.  The implementation of this class may be empty.
+However, the version included in this module has provides some additional
+setup.  The parameters used to override default values are:
+
+* `cli_jar`
+* `port`
+* `ssh_private_key`
+* `puppet_helper`
+* `cli_tries`
+* `cli_try_sleep`
+
+An example of setting a non-default path to the ssh key used to authenticate the
+`cli` with jenkins are reducing the number of retry attempts.
+
+```
+class { 'jenkins::cli::config':
+  ssh_private_key => '/home/vagrant/insecure_private_key',
+  cli_tries       => 3,
+  cli_try_sleep   => 1,
+}
+```
+
+These values may also be set via facts with the same name after the prefix
+`jenkins_`.  Class parameters have precedence over fact values.
+
+* `jenkins_cli_jar`
+* `jenkins_port`
+* `jenkins_ssh_private_key`
+* `jenkins_puppet_helper`
+* `jenkins_cli_tries`
+* `jenkins_cli_try_sleep`
+
+Configuration via facts is particularly convenient for testing via the `resource` face. For example:
+
+```
+export FACTER_jenkins_puppet_helper=/tmp/vagrant-puppet/modules-998ea1817cb4dea9c136a57fd18781c5/jenkins/files/puppet_helper.groov
+export FACTER_jenkins_cli_tries=2
+export FACTER_jenkins_ssh_private_key=/home/vagrant/insecure_private_key
+
+puppet resource --modulepath=/tmp/vagrant-puppet/modules-998ea1817cb4dea9c136a57fd18781c5/ jenkins_user --debug --trace
+```
+
+The ruby gem `retries` is presently required by all providers.
+
+Types
+--
+
+### `jenkins_authorization_strategy`
+
+```
+jenkins_authorization_strategy { '<jenkins AuthorizationStrategy class name>':
+  ensure    => 'present', # present | absent
+  arguments => [],        # array of arguments to class constructor
+}
+```
+
+#### "Anyone can do anything"
+
+```
+jenkins_authorization_strategy { 'hudson.security.AuthorizationStrategy$Unsecured':
+  ensure => 'present',
+}
+```
+
+#### "Github Commiter Authorization Strategy"
+
+Provided by the [`github-oauth`](https://wiki.jenkins-ci.org/display/JENKINS/Github+OAuth+Plugin) plugin.
+
+```
+jenkins_authorization_strategy { 'org.jenkinsci.plugins.GithubAuthorizationStrategy':
+  ensure    => 'present',
+  arguments => [
+    'admin',
+    true,
+    false,
+    false,
+    lsst,
+    false,
+    false,
+    false,
+  ],
+}
+```
+
+Order of arguments is:
+
+* `adminUserNames`
+* `authenticatedUserReadPermission`
+* `useRepositoryPermissions`
+* `authenticatedUserCreateJobPermission`
+* `organizationNames`
+* `allowGithubWebHookPermission`
+* `allowCcTrayPermission`
+* `allowAnonymousReadPermission`
+
+XXX Would `arguments` be more convenient as a hash?
+
+#### "Legacy mode"
+
+XXX requires additional configuration???
+
+```
+jenkins_authorization_strategy { 'hudson.security.LegacyAuthorizationStrategy':
+  ensure => 'present',
+}
+```
+
+#### "Logged-in users can do anything"
+
+```
+jenkins_authorization_strategy { 'hudson.security.FullControlOnceLoggedInAuthorizationStrategy':
+  ensure => 'present',
+  }
+```
+
+#### "Matrix-based security"
+
+XXX does not currently support configuring the access matrix -- this make it
+essentially unusable as setting this strategy will lock out the cli
+```
+jenkins_authorization_strategy { 'hudson.security.GlobalMatrixAuthorizationStrategy':
+  ensure => 'present',
+}
+```
+
+#### "Project-based Matrix Authorization Strategy"
+
+XXX same issue as `hudson.security.GlobalMatrixAuthorizationStrategy`
+
+```
+jenkins_authorization_strategy { 'hudson.security.ProjectMatrixAuthorizationStrategy':
+  ensure => 'present',
+}
+```
+
+#### disabling any resource name is equivalent to setting `hudson.security.AuthorizationStrategy$Unsecured`
+```
+jenkins_authorization_strategy { 'hudson.security.FullControlOnceLoggedInAuthorizationStrategy':
+  ensure => absent
+}
+```
+
+### `jenkins_credentials`
+
+Note that unlike `jenkins::credentials` the resource name is the jenkins' `id`
+instead of the credentials' `username`.  This is necessary as `username` is not
+unique event within a domain and not all credentials types have a `username`
+property.
+
+```
+jenkins_credentials { '<id>':
+  ensure      => 'present', # present | absent
+  description => 'description',
+  domain      => undef,     # undef is the global domain; only allowed value
+  impl        => '<jenkins credentials class short name>',
+  password    => 'password',
+  scope       => 'GLOBAL',  # GLOBAL | SYSTEM
+  username    => 'username',
+  passphrase  => '',        # currently buggy when unset
+  private_key => '<ssh private key as string>',
+}
+```
+
+* `impl`
+
+* `UsernamePasswordCredentialsImpl`
+* `BasicSSHUserPrivateKey`
+
+XXX This type has properties for other credentials classes that are not currently supported.
+
+
+#### `UsernamePasswordCredentialsImpl`
+
+```
+jenkins_credentials { 'my unique id':
+  ensure      => 'present',
+  description => 'account info for user bar',
+  domain      => 'undef',
+  impl        => 'UsernamePasswordCredentialsImpl',
+  password    => 'password',
+  scope       => 'GLOBAL',
+  username    => 'bar',
+}
+```
+
+#### `BasicSSHUserPrivateKey`
+
+```
+jenkins_credentials { 'a0469025-1202-4007-983d-0c62f230f1a7':
+  ensure      => 'present',
+  description => 'ssh key for user foo',
+  domain      => undef,
+  impl        => 'BasicSSHUserPrivateKey',
+  passphrase  => '',
+  private_key => '-----BEGIN RSA PRIVATE KEY----- ...',
+  scope       => 'GLOBAL',
+  username    => 'foo',
+}
+```
+
+### `jenkins_job`
+
+```
+jenkins_job { 'job name':
+  config => '<xml config string>',
+  enable => true, # true | false
+}
+```
+
+XXX Note that enable is prefetch correctly but the value is ignored when
+syncing.
+
+```
+jenkins_job { 'myjob':
+  ensure => 'present',
+  config => '<?xml version="1.0" encoding="UTF-8"?><project>
+  <actions/>
+  <description/>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>',
+  enable => true,
+}
+```
+
+### `jenkins_num_executors`
+
+```
+jenkins_num_executors { 42: # name is coerced to Integer
+  ensure => 'present', # present is the only allowed value
+}
+```
+
+XXX Note that it is possible to declare this resource multiple times.  Each
+instance will set the value.
+
+### `jenkins_security_realm`
+
+
+#### "Delegate to servlet container"
+
+```
+jenkins_security_realm { 'hudson.security.LegacySecurityRealm':
+  ensure => 'present',
+}
+```
+
+#### "Github Authentication Plugin"
+
+Provided by the [`github-oauth`](https://wiki.jenkins-ci.org/display/JENKINS/Github+OAuth+Plugin) plugin.
+
+```
+jenkins_security_realm { 'org.jenkinsci.plugins.GithubSecurityRealm':
+  ensure    => 'present',
+  arguments => [
+    'https://github.com',
+    'https://api.github.com',
+    'c4d1...',
+    'a4ca...',
+    'repo,read:org',
+  ],
+}
+```
+
+Order of arguments is:
+
+* `githubWebUri`
+* `githubApiUri`
+* `clientID`
+* `clientSecret`
+* `oauthScopes`
+
+#### "Jenkins’ own user database"
+
+```
+jenkins_security_realm { 'hudson.security.HudsonPrivateSecurityRealm':
+  ensure    => 'present',
+  arguments => [true, false, undef],
+}
+```
+
+Order of arguments is:
+
+* allowSignup
+* enableCaptcha
+* <always undef>
+
+#### "LDAP"
+
+__unsupported__
+
+#### "Unix user/group database"
+
+```
+jenkins_security_realm { 'hudson.security.PAMSecurityRealm':
+  ensure    => 'present',
+  arguments => ['sshd'], # service name
+}
+```
+
+### `jenkins_slaveagent_port`
+
+```
+jenkins_slaveagent_port { 44444: # name is coerced to Integer
+  ensure => 'present', # present is the only allowed value
+}
+```
+
+XXX Note that it is possible to declare this resource multiple times.  Each
+instance will set the value.
+
+### `jenkins_user`
+
+```
+jenkins_user { 'admin':
+  ensure           => 'present',
+  api_token_plain  => '29fedb889e8ccf649bfdada5d9e8c519',
+  api_token_public => '03b99b3d93a5dc6193dbe7d97acaa0a6',
+  email_address    => 'foo@example.org',
+  full_name        => 'jenkins admin',
+  password         => '#jbcrypt:$2a$10$wFyDgWYOHauojVfxiXWD3OTJMt6vE.j6eJol8uYMdZ5JrZ2lj9xny',
+  public_keys      => ['ssh-rsa AAAA...'],
+}
+```
+
+* `api_token_public`
+
+A _read-only_ property; jenkins does not support setting the token
+
+* `api_token_plain`
+
+The jenkins internal only value that is hashed to produce the public API token.
+This value can be set for a user by violating a private interface.  This value
+may be discovered by using the puppet resource face.
+
+* `password`
+
+May be a plain string but this will be non-idempotent.  The hash string value
+may be discovered with the puppet resource face.
+
+
+TODO
+--
+
+* beaker/acceptance tests that exercise all types/providers
+
+* integrate types with existing DSL defined types
+
+* determine if these types should be a "public interface" or considered private
+  to the module
+
+* rename some of the new `puppet_helper.groovy` methods for consistency and add
+  descriptive comments to all methods
+
+* determine what to do about `jenkins_job` `enable` parameter which potentially
+  breaks idempotency
+
+* add a method to `puppet_helper.groovy` to list all jobs so that `jenkins_job`
+  does not need to make multiple cli invocations when prefetching
+
+* test that the transition from authentication being required to disabled is
+  properly handled
+
+* fix `jenkins_credentials` handling of a blank `passphrase` for
+  `BasicSSHUserPrivateKey`

--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -470,6 +470,7 @@ class Actions {
           break
         case com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey:
           info['description'] = cred.description
+          info['username'] = cred.username
           info['private_key'] = cred.privateKey
           info['passphrase'] = cred.passphrase.plainText
           break

--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -861,6 +861,17 @@ class Actions {
      j.setSlaveAgentPort(n.toInteger())
      j.save()
   }
+
+  /////////////////////////
+  // job_enabled
+  /////////////////////////
+  /*
+   * Print the job's state as either "true" or "false"
+  */
+  void job_enabled(String name) {
+    def disabled = Jenkins.getInstance().getJob(name).isDisabled()
+    out.println(!disabled)
+  }
 } // class Actions
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/lib/puppet/feature/retries.rb
+++ b/lib/puppet/feature/retries.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:retries, libs: 'retries')

--- a/lib/puppet/provider/jenkins_authorization_strategy/cli.rb
+++ b/lib/puppet/provider/jenkins_authorization_strategy/cli.rb
@@ -1,0 +1,92 @@
+require 'puppet_x/jenkins/util'
+require 'puppet_x/jenkins/provider/cli'
+
+Puppet::Type.type(:jenkins_authorization_strategy).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
+
+  mk_resource_methods
+
+  def self.instances(catalog = nil)
+    all = get_authorization_strategy(catalog)
+
+    # we are assuming there is only one key hash
+    Puppet.debug("#{sname} instances: #{all.keys}")
+
+    [from_hash(all)]
+  end
+
+  def flush
+    unless resource.nil?
+      @property_hash = resource.to_hash
+    end
+
+    case self.ensure
+    when :present
+      set_jenkins_instance
+    when :absent
+      set_strategy_unsecured
+    else
+      fail("invalid :ensure value: #{self.ensure}")
+    end
+  end
+
+  private
+
+  def self.from_hash(info)
+    method_name = 'setAuthorizationStrategy'
+    class_name = info[method_name].keys.first
+    ctor_args = info[method_name][class_name]
+
+    args = {
+      :name      => class_name,
+      :ensure    => :present,
+      :arguments => ctor_args,
+    }
+
+    # map nil -> :undef
+    args = PuppetX::Jenkins::Util.undefize(args)
+    new(args)
+  end
+  private_class_method :from_hash
+
+  def to_hash
+    ctor = {}
+
+    if arguments == :absent
+      ctor[name] = []
+    else
+      ctor[name] = arguments
+    end
+    Puppet.debug("to_hash arguments #{arguments}")
+
+    info = { "setAuthorizationStrategy" => ctor }
+    # map :undef -> nil
+    PuppetX::Jenkins::Util.unundef(info)
+  end
+
+  # jenkins only supports a single configured security realm at a time
+  def self.get_authorization_strategy(catalog = nil)
+    raw = clihelper(['get_authorization_strategy'], :catalog => catalog)
+
+    begin
+      JSON.parse(raw)
+    rescue JSON::ParserError
+      fail("unable to parse as JSON: #{raw}")
+    end
+  end
+  private_class_method :get_authorization_strategy
+
+  def set_jenkins_instance(input = nil)
+    input ||= to_hash
+
+    clihelper(['set_jenkins_instance'], :stdinjson => input)
+  end
+
+  def set_strategy_unsecured
+    input = {
+      "setAuthorizationStrategy" => {
+        "hudson.security.AuthorizationStrategy$Unsecured" => [],
+      },
+    }
+    set_jenkins_instance(input)
+  end
+end

--- a/lib/puppet/provider/jenkins_credentials/cli.rb
+++ b/lib/puppet/provider/jenkins_credentials/cli.rb
@@ -1,0 +1,118 @@
+require 'puppet/util/warnings'
+
+require 'puppet_x/jenkins/util'
+require 'puppet_x/jenkins/provider/cli'
+
+Puppet::Type.type(:jenkins_credentials).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
+
+  mk_resource_methods
+
+  def self.instances(catalog = nil)
+    all = credentials_list_json(catalog)
+
+    Puppet.debug("#{sname} instances: #{all.collect {|i| i['id']}}")
+
+    all.collect {|info| from_hash(info) }
+  end
+
+  def flush
+    unless resource.nil?
+      @property_hash = resource.to_hash
+    end
+
+    case self.ensure
+    when :present
+      credentials_update_json
+    when :absent
+      credentials_delete_id
+    else
+      fail("invalid :ensure value: #{self.ensure}")
+    end
+  end
+
+  private
+  def self.copy_key(dst, src, key)
+    dst[key.to_sym] = src[key.to_s]
+  end
+  private_class_method :copy_key
+
+  def self.from_hash(info)
+    # map nil -> :undef
+    info = PuppetX::Jenkins::Util.undefize(info)
+
+    params = {
+      :name   => info['id'],
+      :ensure => :present,
+    }
+
+    [:impl, :domain, :scope].each {|k| copy_key(params, info, k)}
+
+    case info['impl']
+    when 'UsernamePasswordCredentialsImpl'
+      [:description, :username, :password].each {|k| copy_key(params, info, k)}
+    when 'BasicSSHUserPrivateKey'
+      [:description, :username, :private_key, :passphrase].each {|k| copy_key(params, info, k)}
+    when 'StringCredentialsImpl'
+      [:description, :secret].each {|k| copy_key(params, info, k)}
+    when 'FileCredentialsImpl'
+      [:description, :file_name, :content].each {|k| copy_key(params, info, k)}
+    when 'CertificateCredentialsImpl'
+      [:description, :password, :key_store_implementation].each {|k| copy_key(params, info, k)}
+
+      ksi = info['key_store_impl']
+      params['key_store_impl'] = ksi
+
+      case ksi
+      when 'UploadedKeyStoreSource'
+        params[:content] = info['content']
+      when 'FileOnMasterKeyStoreSource'
+        params[:source] = info['source']
+      else
+        Puppet::Util::Warnings.debug_once "#{sname}: unsupported key_store_implementation class #{ksi}"
+      end
+    else
+      Puppet::Util::Warnings.debug_once "#{sname}: unsupported implementation class #{info['impl']}"
+    end
+
+    new(params)
+  end
+  private_class_method :from_hash
+
+  def to_hash
+    info = { 'id' => name }
+
+    properties = self.class.resource_type.validproperties
+    properties.reject! {|x| x == :ensure }
+
+    properties.each do |prop|
+      value = @property_hash[prop]
+      unless value.nil?
+        info[prop.to_s] = value
+      end
+    end
+
+    # map :undef -> nil
+    PuppetX::Jenkins::Util.unundef(info)
+  end
+
+  # array of hashes for multiple "credentials" entries
+  def self.credentials_list_json(catalog = nil)
+    raw = clihelper(['credentials_list_json'], :catalog => catalog)
+
+    begin
+      JSON.parse(raw)
+    rescue JSON::ParserError
+      fail("unable to parse as JSON: #{raw}")
+    end
+  end
+  private_class_method :credentials_list_json
+
+  def credentials_update_json
+    clihelper(['credentials_update_json'], :stdinjson => to_hash)
+  end
+
+  def credentials_delete_id
+    # name == "id"
+    clihelper(['credentials_delete_id', name])
+  end
+end

--- a/lib/puppet/provider/jenkins_job/cli.rb
+++ b/lib/puppet/provider/jenkins_job/cli.rb
@@ -71,7 +71,7 @@ Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provi
 
   def self.job_enabled(job, catalog = nil)
     raw = clihelper(['job_enabled', job], :catalog => catalog)
-    raw == 'true'
+    !!(raw =~ /true/)
   end
   private_class_method :job_enabled
 

--- a/lib/puppet/provider/jenkins_job/cli.rb
+++ b/lib/puppet/provider/jenkins_job/cli.rb
@@ -1,0 +1,89 @@
+require 'puppet/util/warnings'
+
+require 'puppet_x/jenkins/util'
+require 'puppet_x/jenkins/provider/cli'
+
+Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
+
+  mk_resource_methods
+
+  def self.instances(catalog = nil)
+    job_names = list_jobs(catalog)
+
+    Puppet.debug("#{sname} instances: #{job_names}")
+
+    # XXX iterating over each job is slow because it requires 2 invocations of
+    # the cli jar.  This should be replaced with a puppet_helper method to
+    # return the configuration for all jobs at once.
+    job_names.collect do |job|
+      new(
+        :name   => job,
+        :ensure => :present,
+        :config => get_job(job, catalog),
+        :enable => job_enabled(job, catalog),
+      )
+    end
+  end
+
+  # ignore #create so we can differentiate in #flush between an update to an
+  # existing job and creating a new one
+  def create
+  end
+
+  def flush
+    update = false
+    if exists?
+      update = true
+    end
+
+    unless resource.nil?
+      @property_hash = resource.to_hash
+    end
+
+    # XXX the enable property is being ignored on flush because this modifies
+    # the configuration string and breaks idempotent.  Should the property be
+    # removed?
+    case self.ensure
+    when :present
+      if update
+        update_job
+      else
+        create_job
+      end
+    when :absent
+      delete_job
+    else
+      fail("invalid :ensure value: #{self.ensure}")
+    end
+  end
+
+  private
+
+  def self.list_jobs(catalog = nil)
+    cli(['list-jobs'], :catalog => catalog).split
+  end
+  private_class_method :list_jobs
+
+  def self.get_job(job, catalog = nil)
+    cli(['get-job', job], :catalog => catalog)
+  end
+  private_class_method :get_job
+
+  def self.job_enabled(job, catalog = nil)
+    raw = clihelper(['job_enabled', job], :catalog => catalog)
+    raw == 'true'
+  end
+  private_class_method :job_enabled
+
+  def create_job
+    cli(['create-job', name], :stdin => config)
+  end
+
+  def update_job
+    cli(['update-job', name], :stdin => config)
+  end
+
+  def delete_job
+    cli(['delete-job', name])
+  end
+end

--- a/lib/puppet/provider/jenkins_num_executors/cli.rb
+++ b/lib/puppet/provider/jenkins_num_executors/cli.rb
@@ -1,0 +1,36 @@
+require 'puppet_x/jenkins/util'
+require 'puppet_x/jenkins/provider/cli'
+
+Puppet::Type.type(:jenkins_num_executors).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
+
+  mk_resource_methods
+
+  def self.instances(catalog = nil)
+    n = get_num_executors(catalog)
+
+    # there can be only one value
+    Puppet.debug("#{sname} instances: #{n}")
+
+    [new(:name => n, :ensure => :prsent)]
+  end
+
+  def flush
+    case self.ensure
+    when :present
+      set_num_executors
+    else
+      fail("invalid :ensure value: #{self.ensure}")
+    end
+  end
+
+  private
+
+  def self.get_num_executors(catalog = nil)
+    clihelper(['get_num_executors'], :catalog => catalog).to_i
+  end
+  private_class_method :get_num_executors
+
+  def set_num_executors
+    clihelper(['set_num_executors', name])
+  end
+end

--- a/lib/puppet/provider/jenkins_security_realm/cli.rb
+++ b/lib/puppet/provider/jenkins_security_realm/cli.rb
@@ -1,0 +1,93 @@
+require 'puppet_x/jenkins/util'
+require 'puppet_x/jenkins/provider/cli'
+
+Puppet::Type.type(:jenkins_security_realm).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
+
+  mk_resource_methods
+
+  def self.instances(catalog = nil)
+    all = get_security_realm(catalog)
+
+    # we are assuming there is only one key hash
+    Puppet.debug("#{sname} instances: #{all.keys}")
+
+    [from_hash(all)]
+  end
+
+  def flush
+    unless resource.nil?
+      @property_hash = resource.to_hash
+    end
+
+    case self.ensure
+    when :present
+      set_jenkins_instance
+    when :absent
+      set_security_none
+    else
+      fail("invalid :ensure value: #{self.ensure}")
+    end
+  end
+
+  private
+
+  def self.from_hash(info)
+    method_name = 'setSecurityRealm'
+    class_name = info[method_name].keys.first
+    ctor_args = info[method_name][class_name]
+
+    args = {
+      :name      => class_name,
+      :ensure    => :present,
+      :arguments => ctor_args,
+    }
+
+    # map nil -> :undef
+    args = PuppetX::Jenkins::Util.undefize(args)
+    new(args)
+  end
+  private_class_method :from_hash
+
+  def to_hash
+    ctor = {}
+
+    if arguments == :absent
+      ctor[name] = []
+    else
+      ctor[name] = arguments
+    end
+
+    Puppet.debug("to_hash arguments #{arguments}")
+
+    info = { 'setSecurityRealm' => ctor }
+    # map :undef -> nil
+    PuppetX::Jenkins::Util.unundef(info)
+  end
+
+  # jenkins only supports a single configured security realm at a time
+  def self.get_security_realm(catalog = nil)
+    raw = clihelper(['get_security_realm'], :catalog => catalog)
+
+    begin
+      JSON.parse(raw)
+    rescue JSON::ParserError
+      fail("unable to parse as JSON: #{raw}")
+    end
+  end
+  private_class_method :get_security_realm
+
+  def set_jenkins_instance(input = nil)
+    input ||= to_hash
+
+    clihelper(['set_jenkins_instance'], :stdinjson => input)
+  end
+
+  def set_security_none
+    input = {
+      "setSecurityRealm" => {
+        "hudson.security.SecurityRealm$None" => [],
+      },
+    }
+    set_jenkins_instance(input)
+  end
+end

--- a/lib/puppet/provider/jenkins_slaveagent_port/cli.rb
+++ b/lib/puppet/provider/jenkins_slaveagent_port/cli.rb
@@ -1,0 +1,36 @@
+require 'puppet_x/jenkins/util'
+require 'puppet_x/jenkins/provider/cli'
+
+Puppet::Type.type(:jenkins_slaveagent_port).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
+
+  mk_resource_methods
+
+  def self.instances(catalog = nil)
+    n = get_slaveagent_port(catalog)
+
+    # there can be only one value
+    Puppet.debug("#{sname} instances: #{n}")
+
+    [new(:name => n, :ensure => :present)]
+  end
+
+  def flush
+    case self.ensure
+    when :present
+      set_slaveagent_port
+    else
+      fail("invalid :ensure value: #{self.ensure}")
+    end
+  end
+
+  private
+
+  def self.get_slaveagent_port(catalog = nil)
+    clihelper(['get_slaveagent_port'], :catalog => catalog).to_i
+  end
+  private_class_method :get_slaveagent_port
+
+  def set_slaveagent_port
+    clihelper(['set_slaveagent_port', name])
+  end
+end

--- a/lib/puppet/provider/jenkins_user/cli.rb
+++ b/lib/puppet/provider/jenkins_user/cli.rb
@@ -1,0 +1,98 @@
+require 'puppet_x/jenkins/util'
+require 'puppet_x/jenkins/provider/cli'
+
+Puppet::Type.type(:jenkins_user).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
+
+  mk_resource_methods
+
+  def self.instances(catalog = nil)
+    all = user_info_all(catalog)
+
+    Puppet.debug("#{sname} instances: #{all.collect {|i| i['id']}}")
+
+    all.collect {|info| from_hash(info) }
+  end
+
+  def api_token_public=(value)
+    fail 'api_token_pubilc is read-only'
+  end
+
+  def flush
+    unless resource.nil?
+      @property_hash = resource.to_hash
+    end
+
+    case self.ensure
+    when :present
+      user_update
+    when :absent
+      delete_user
+    else
+      fail("invalid :ensure value: #{self.ensure}")
+    end
+  end
+
+  private
+
+  def self.from_hash(info)
+    # map nil -> :undef
+    info = PuppetX::Jenkins::Util.undefize(info)
+
+    new({
+      :name             => info['id'],
+      :ensure           => :present,
+      :full_name        => info['full_name'],
+      :email_address    => info['email_address'],
+      :api_token_plain  => info['api_token_plain'],
+      :api_token_public => info['api_token_public'],
+      :public_keys      => info['public_keys'],
+      :password         => info['password'],
+    })
+  end
+  private_class_method :from_hash
+
+  def to_hash
+    info = { 'id' => name }
+
+    properties = self.class.resource_type.validproperties
+    properties.reject! {|x| x == :ensure }
+    properties.reject! {|x| x == :api_token_public}
+
+    properties.each do |prop|
+      value = @property_hash[prop]
+      unless value.nil?
+        info[prop.to_s] = value
+      end
+    end
+
+    # map :undef -> nil
+    PuppetX::Jenkins::Util.unundef(info)
+  end
+
+  # array of hashes for multiple users
+  def self.user_info_all(catalog = nil)
+    raw = nil
+    unless catalog.nil?
+      raw = clihelper(['user_info_all'], :catalog => catalog)
+    else
+      raw = clihelper(['user_info_all'])
+    end
+
+    begin
+      JSON.parse(raw)
+    rescue JSON::ParserError
+      fail("unable to parse as JSON: #{raw}")
+    end
+  end
+  private_class_method :user_info_all
+
+  def user_update
+    input ||= to_hash
+
+    clihelper(['user_update'], :stdinjson => input)
+  end
+
+  def delete_user
+    clihelper(['delete_user', name])
+  end
+end

--- a/lib/puppet/type/jenkins_authorization_strategy.rb
+++ b/lib/puppet/type/jenkins_authorization_strategy.rb
@@ -1,0 +1,34 @@
+require 'puppet_x/jenkins/type/cli'
+
+PuppetX::Jenkins::Type::Cli.newtype(:jenkins_authorization_strategy) do
+  @doc = "Manage Jenkins' authorization strategy"
+
+  ensurable
+
+  newparam(:name) do
+    desc 'Name of the security realm class'
+    isnamevar
+  end
+
+  newproperty(:arguments, :array_matching => :all) do
+    desc 'List of arguments to security realm class constructor'
+  end
+
+  # require all instances of jenkins_user as the authorization strategy being
+  # converged might require one of those accounts for administrative control
+  autorequire(:jenkins_user) do
+    catalog.resources.find_all do |r|
+     r.is_a?(Puppet::Type.type(:jenkins_user))
+    end
+  end
+
+  # the authorization strategy can potentially lockout all access if it is
+  # configured but the security realm is none
+  autorequire(:jenkins_security_realm) do
+    if self[:ensure] == :present
+      catalog.resources.find_all do |r|
+       r.is_a?(Puppet::Type.type(:jenkins_security_realm))
+      end
+    end
+  end
+end # PuppetX::Jenkins::Type::Cli.newtype

--- a/lib/puppet/type/jenkins_credentials.rb
+++ b/lib/puppet/type/jenkins_credentials.rb
@@ -1,0 +1,89 @@
+require 'puppet_x/jenkins/type/cli'
+
+PuppetX::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
+  @doc = <<-EOS
+    Manage Jenkins' credentials
+
+    XXX The properties specified are not validated against the specified
+        jenkins class (`impl`)
+  EOS
+
+  ensurable
+
+  newparam(:name) do
+    desc 'Id for credentials entry'
+    isnamevar
+  end
+
+  newproperty(:domain) do
+    desc 'credentials domain within jenkins - :undef indicates the "global" domain'
+    defaultto :undef
+    newvalues(:undef)
+  end
+
+  newproperty(:scope) do
+    desc 'credentials scope within jenkins'
+    defaultto :GLOBAL
+    newvalues(:GLOBAL, :SYSTEM)
+  end
+
+  newproperty(:impl) do
+    desc 'name of the java class implimenting the credential'
+    defaultto :UsernamePasswordCredentialsImpl
+    newvalues(:UsernamePasswordCredentialsImpl, :BasicSSHUserPrivateKey)
+  end
+
+  newproperty(:description) do
+    desc 'description of credentials'
+    defaultto 'Managed by Puppet'
+  end
+
+  newproperty(:username) do
+    desc 'username for credentials - UsernamePasswordCredentialsImpl, CertificateCredentialsImpl'
+  end
+
+  newproperty(:password) do
+    desc 'password - UsernamePasswordCredentialsImpl, CertificateCredentialsImpl'
+  end
+
+  newproperty(:private_key) do
+    desc 'ssh private key string - BasicSSHUserPrivateKey'
+  end
+
+  newproperty(:passphrase) do
+    desc 'passphrase to unlock ssh private key - BasicSSHUserPrivateKey'
+  end
+
+  newproperty(:secret) do
+    desc 'secret string - StringCredentialsImpl'
+  end
+
+  newproperty(:file_name) do
+    desc 'name of file - FileCredentialsImpl'
+  end
+
+  newproperty(:content) do
+    desc 'content of file - FileCredentialsImpl, CertificateCredentialsImpl'
+  end
+
+  newproperty(:source) do
+    desc 'content of file - CertificateCredentialsImpl'
+  end
+
+  newproperty(:key_store_impl) do
+    desc 'name of the java class implimenting the key store - CertificateCredentialsImpl'
+  end
+
+  # require all authentication & authorization related types
+  [
+    :jenkins_user,
+    :jenkins_security_realm,
+    :jenkins_authorization_strategy,
+  ].each do |type|
+    autorequire(type) do
+      catalog.resources.find_all do |r|
+       r.is_a?(Puppet::Type.type(type))
+      end
+    end
+  end
+end # PuppetX::Jenkins::Type::Cli.newtype

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -1,0 +1,36 @@
+require 'puppet/property/boolean'
+
+require 'puppet_x/jenkins/type/cli'
+
+PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
+  @doc = "Manage Jenkins' jobs"
+
+  ensurable
+
+  newparam(:name) do
+    desc 'job name'
+    isnamevar
+  end
+
+  newproperty(:config) do
+    desc 'XML job configuration string'
+  end
+
+  newproperty(:enable, :boolean => true, :parent => Puppet::Property::Boolean) do
+    desc 'enable/disable job'
+    defaultto true
+  end
+
+  # require all authentication & authorization related types
+  [
+    :jenkins_user,
+    :jenkins_security_realm,
+    :jenkins_authorization_strategy,
+  ].each do |type|
+    autorequire(type) do
+      catalog.resources.find_all do |r|
+       r.is_a?(Puppet::Type.type(type))
+      end
+    end
+  end
+end # PuppetX::Jenkins::Type::Cli.newtype

--- a/lib/puppet/type/jenkins_num_executors.rb
+++ b/lib/puppet/type/jenkins_num_executors.rb
@@ -1,0 +1,37 @@
+require 'puppet_x/jenkins/type/cli'
+
+PuppetX::Jenkins::Type::Cli.newtype(:jenkins_num_executors) do
+  @doc = "Manage Jenkins' number of executor slots"
+
+  # the cli jar does not have an interface for plugin removal so the only
+  # allowed ensure value is :present
+  ensurable do
+    newvalue(:present) { provider.create }
+  end
+
+  newparam(:name) do
+    desc 'Number of executors'
+    isnamevar
+
+    munge do |value|
+      if value.is_a?(String) and value =~ /^[0-9]+$/
+        Integer(value)
+      else
+        value
+      end
+    end
+  end
+
+  # require all authentication & authorization related types
+  [
+    :jenkins_user,
+    :jenkins_security_realm,
+    :jenkins_authorization_strategy,
+  ].each do |type|
+    autorequire(type) do
+      catalog.resources.find_all do |r|
+       r.is_a?(Puppet::Type.type(type))
+      end
+    end
+  end
+end # PuppetX::Jenkins::Type::Cli.newtype

--- a/lib/puppet/type/jenkins_security_realm.rb
+++ b/lib/puppet/type/jenkins_security_realm.rb
@@ -1,0 +1,34 @@
+require 'puppet_x/jenkins/type/cli'
+
+PuppetX::Jenkins::Type::Cli.newtype(:jenkins_security_realm) do
+  @doc = "Manage Jenkins' security realm"
+
+  ensurable
+
+  newparam(:name) do
+    desc 'Name of the security realm class'
+    isnamevar
+  end
+
+  newproperty(:arguments, :array_matching => :all) do
+    desc 'List of arguments to security realm class constructor'
+  end
+
+  # require all instances of jenkins_user, as does
+  # jenkins_authorization_strategy, to ensure that the state of jenkins_user
+  # resources is not attempted to be modify between jenkins_security_realm and
+  # jenkins_authorization_strategy state changes.
+  autorequire(:jenkins_user) do
+    catalog.resources.find_all do |r|
+     r.is_a?(Puppet::Type.type(:jenkins_user))
+    end
+  end
+
+  autorequire(:jenkins_authorization_strategy) do
+    if self[:ensure] == :absent
+      catalog.resources.find_all do |r|
+       r.is_a?(Puppet::Type.type(:jenkins_authorization_strategy))
+      end
+    end
+  end
+end # PuppetX::Jenkins::Type::Cli.newtype

--- a/lib/puppet/type/jenkins_slaveagent_port.rb
+++ b/lib/puppet/type/jenkins_slaveagent_port.rb
@@ -1,0 +1,37 @@
+require 'puppet_x/jenkins/type/cli'
+
+PuppetX::Jenkins::Type::Cli.newtype(:jenkins_slaveagent_port) do
+  @doc = "Manage Jenkins' slave agent listening port"
+
+  # the cli jar does not have an interface for plugin removal so the only
+  # allowed ensure value is :present
+  ensurable do
+    newvalue(:present) { provider.create }
+  end
+
+  newparam(:name) do
+    desc 'port number'
+    isnamevar
+
+    munge do |value|
+      if value.is_a?(String) and value =~ /^[0-9]+$/
+        Integer(value)
+      else
+        value
+      end
+    end
+  end
+
+  # require all authentication & authorization related types
+  [
+    :jenkins_user,
+    :jenkins_security_realm,
+    :jenkins_authorization_strategy,
+  ].each do |type|
+    autorequire(type) do
+      catalog.resources.find_all do |r|
+       r.is_a?(Puppet::Type.type(type))
+      end
+    end
+  end
+end # PuppetX::Jenkins::Type::Cli.newtype

--- a/lib/puppet/type/jenkins_user.rb
+++ b/lib/puppet/type/jenkins_user.rb
@@ -1,0 +1,42 @@
+require 'puppet_x/jenkins/type/cli'
+
+PuppetX::Jenkins::Type::Cli.newtype(:jenkins_user) do
+  @doc = "Manage Jenkins' user account information"
+
+  ensurable
+
+  newparam(:name) do
+    desc "Account login name.  Jenkins calls this 'id'"
+    isnamevar
+  end
+
+  newproperty(:full_name) do
+    desc 'Optional longer account name.'
+  end
+
+  newproperty(:email_address) do
+    desc 'email address'
+  end
+
+  newproperty(:api_token_plain) do
+    desc "Unhashed or 'plain_text' API token that is digested to produce the public API token"
+    validate do |value|
+      # 32 char hex string
+      unless (value =~ /^\h{32}$/)
+        raise ArgumentError, "#{value} is not a 32char hex string"
+      end
+    end
+  end
+
+  newproperty(:api_token_public) do
+    desc 'Literal public API token.  read-only property.'
+  end
+
+  newproperty(:public_keys, :array_matching => :all) do
+    desc 'Array of ssh public key strings'
+  end
+
+  newproperty(:password) do
+    desc 'Password for HudsonPrivateSecurityRealm'
+  end
+end # PuppetX::Jenkins::Type::Cli.newtype

--- a/lib/puppet/type/jenkins_user.rb
+++ b/lib/puppet/type/jenkins_user.rb
@@ -29,6 +29,7 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_user) do
   end
 
   newproperty(:api_token_public) do
+    # XXX validate
     desc 'Literal public API token.  read-only property.'
   end
 

--- a/lib/puppet_x/jenkins.rb
+++ b/lib/puppet_x/jenkins.rb
@@ -1,0 +1,2 @@
+module PuppetX; end
+module PuppetX::Jenkins; end

--- a/lib/puppet_x/jenkins/config.rb
+++ b/lib/puppet_x/jenkins/config.rb
@@ -1,6 +1,7 @@
 require 'facter'
 
 require 'puppet_x/jenkins'
+require 'puppet/util/warnings'
 
 # This class is used to lookup common configuration values by first looking for
 # the desired key as parameter to the config class in the catalog, then
@@ -30,9 +31,15 @@ class PuppetX::Jenkins::Config
     value = catalog_lookup(key) || fact_lookup(key) || default_lookup(key)
     return if value.nil?
 
+    Puppet::Util::Warnings.debug_once "config: #{key} = #{value}"
+
     # handle puppet 3.x passing in all values as strings and convert back to
     # Integer/Fixnum
-    default_type_integer?(key) ? value.to_i : value
+    if Puppet.version =~ /^3/
+      default_type_integer?(key) ? value.to_i : value
+    else
+      value
+    end
   end
 
   def catalog_lookup(key)

--- a/lib/puppet_x/jenkins/config.rb
+++ b/lib/puppet_x/jenkins/config.rb
@@ -1,0 +1,59 @@
+require 'facter'
+
+require 'puppet_x/jenkins'
+
+# This class is used to lookup common configuration values by first looking for
+# the desired key as parameter to the config class in the catalog, then
+# checking for a prefixed fact, and falling back to hard coded defaults.
+class PuppetX::Jenkins::Config
+  class UnknownConfig < ArgumentError; end
+
+  DEFAULTS = {
+    :cli_jar         => '/usr/lib/jenkins/jenkins-cli.jar',
+    :port            => 8080,
+    :ssh_private_key => nil,
+    :puppet_helper   => '/usr/lib/jenkins/puppet_helper.groovy',
+    :cli_tries       => 30,
+    :cli_try_sleep   => 2,
+  }
+  CONFIG_CLASS = 'jenkins::cli::config'
+  FACT_PREFIX = 'jenkins_'
+
+  def initialize(catalog = nil)
+    @catalog = catalog
+  end
+
+  def [](key)
+    key = key.to_sym
+    raise UnknownConfig unless DEFAULTS.has_key?(key)
+
+    value = catalog_lookup(key) || fact_lookup(key) || default_lookup(key)
+    return if value.nil?
+
+    # handle puppet 3.x passing in all values as strings and convert back to
+    # Integer/Fixnum
+    default_type_integer?(key) ? value.to_i : value
+  end
+
+  def catalog_lookup(key)
+    return nil if @catalog.nil?
+
+    config = @catalog.resource(:class, CONFIG_CLASS)
+    return nil if config.nil?
+
+    config[key.to_sym]
+  end
+
+  def fact_lookup(key)
+    fact = FACT_PREFIX + key.to_s
+    Facter.value(fact.to_sym)
+  end
+
+  def default_lookup(key)
+    DEFAULTS[key]
+  end
+
+  def default_type_integer?(key)
+    DEFAULTS[key].is_a?(Integer)
+  end
+end

--- a/lib/puppet_x/jenkins/provider.rb
+++ b/lib/puppet_x/jenkins/provider.rb
@@ -1,0 +1,3 @@
+require 'puppet_x/jenkins'
+
+module PuppetX::Jenkins::Provider; end

--- a/lib/puppet_x/jenkins/provider/cli.rb
+++ b/lib/puppet_x/jenkins/provider/cli.rb
@@ -1,0 +1,239 @@
+require 'puppet/provider'
+require 'facter'
+
+require 'puppet_x/jenkins/config'
+require 'puppet_x/jenkins/provider'
+
+class PuppetX::Jenkins::Provider::Cli < Puppet::Provider
+  # stdout/stderr indicates an authentication failure
+  class AuthError < Puppet::ExecutionFailure; end
+  # any other execution error
+  class UnknownError < Puppet::ExecutionFailure; end
+
+  # push a shallow copy of the class confines into the subclass
+  # this includes the confine(s) needed for commands
+  #
+  # The subclass seems to function with an empty @commands and any value we try
+  # to push in will get reselt by ::initvars.
+  def self.inherited(subclass)
+    subclass.instance_variable_set(:@confine_collection, @confine_collection.dup)
+  end
+
+  # we must invoke ::initvars to setup variables needed by ::commands
+  self.initvars
+
+  commands :java => 'java'
+  confine :feature => :retries
+
+  # subclasses should inherit this value once it has been determined that
+  # jenkins requires authorization, it shortens the run time be elemating the
+  # need for each subclass to retest for an authenication failure.
+  #
+  # XXX this needs some consideration for how to handle the transistion from
+  # security being enabled to disabled
+  class_variable_set(:@@cli_auth_required, false)
+
+  # shorter class name
+  def self.sname
+    self.to_s[/.+::(Jenkins.+)/, 1]
+  end
+
+  def self.prefetch(resources)
+    Puppet.debug("#{sname} prefetch: #{resources.each_key.collect.to_a}")
+
+    catalog = resources.first[1].catalog
+
+    instances(catalog).each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def create
+    @property_hash[:ensure] = :present
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def destroy
+    @property_hash[:ensure] = :absent
+  end
+
+  def flush
+    @property_hash.clear
+  end
+
+  # if the provider instance has a resource (which it should outside of
+  # testing), add :catalog to the options hash so the caller doesn't have to
+  def clihelper(command, options = nil)
+    if resource and resource.catalog
+      options ||= {}
+      options[:catalog] ||= resource.catalog
+    end
+
+    args = []
+    args << command
+    args << options unless options.nil?
+    self.class.clihelper(*args)
+  end
+
+  def cli(command, options = nil)
+    if resource and resource.catalog
+      options ||= {}
+      options[:catalog] ||= resource.catalog
+    end
+
+    args = []
+    args << command
+    args << options unless options.nil?
+    self.class.cli(*args)
+  end
+
+  def self.clihelper(command, options = nil)
+    catalog = options.nil? ? nil : options[:catalog]
+    config = PuppetX::Jenkins::Config.new(catalog)
+
+    puppet_helper = config[:puppet_helper]
+
+    cli_cmd = ['groovy', puppet_helper] + [command]
+    cli_cmd.flatten!
+
+    cli(cli_cmd, options)
+  end
+
+  def self.cli(command, options = {})
+    if options.nil? || !options.key?(:stdinjson) && !options.key?(:stdin)
+      return execute_with_retry(command, options)
+    end
+
+    if options.key?(:stdinjson)
+      data = options.delete(:stdinjson)
+      input = JSON.pretty_generate(data)
+    end
+
+    if options.key?(:stdin)
+      input = options.delete(:stdin)
+    end
+
+    Puppet.debug("#{sname} stdin:\n#{input}")
+
+    # a tempfile block arg is not used to simplify mock testing :/
+    tmp = Tempfile.open(sname)
+    tmp.write input
+    tmp.flush
+    options[:stdinfile] = tmp.path
+    result = execute_with_retry(command, options)
+    tmp.close
+    tmp.unlink
+
+    result
+  end
+
+  def self.execute_with_retry(command, options = {})
+    options ||= {}
+    catalog = options.delete(:catalog)
+
+    options.merge!({ :failonfail => true })
+    # without combine, an execution exception message will not include the
+    # stderr
+    options.merge!({ :combine => true })
+
+    config = PuppetX::Jenkins::Config.new(catalog)
+    cli_jar         = config[:cli_jar]
+    port            = config[:port]
+    ssh_private_key = config[:ssh_private_key]
+    cli_tries       = config[:cli_tries]
+    cli_try_sleep   = config[:cli_try_sleep]
+
+    base_cmd = [
+      command(:java),
+      '-jar', cli_jar,
+      '-s', "http://localhost:#{port}",
+    ]
+
+    cli_cmd = base_cmd + [command]
+    cli_cmd.flatten!
+
+    auth_cmd = nil
+    unless ssh_private_key.nil?
+      auth_cmd = base_cmd + ['-i', ssh_private_key] + [command]
+      auth_cmd.flatten!
+    end
+
+    # retry on "unknown" execution errors but don't catch AuthErrors.  If an
+    # AuthError has bubbled up to this level it means either an ssh_private_key
+    # is required and we don't have one or that one we have was rejected.
+    handler = Proc.new do |exception, attempt_number, total_delay|
+      Puppet.debug("#{sname} caught #{exception.class.to_s.match(/::([^:]+)$/)[1]}; retry attempt #{attempt_number}; #{total_delay.round(3)} seconds have passed")
+    end
+    with_retries(
+      :max_tries          => cli_tries,
+      :base_sleep_seconds => 1,
+      :max_sleep_seconds  => cli_try_sleep,
+      :rescue             => UnknownError,
+      :handler            => handler,
+    ) do
+      result = execute_with_auth(cli_cmd, auth_cmd, options)
+      unless result == ''
+        Puppet.debug("#{sname} command stdout:\n#{result}")
+      end
+      return result
+    end
+  end
+  private_class_method :execute_with_retry
+
+  def self.execute_with_auth(cli_cmd, auth_cmd, options = {})
+    # auth will fail if if it is attempted with an ssh_private_key that
+    # hasn't yet been configured for a user.
+    Puppet.debug("#{sname} cli_auth_required: #{class_variable_get(:@@cli_auth_required)}")
+
+    # if no ssh_private_key is defined, the only option is to invoke the cli
+    # without auth
+    if auth_cmd.nil?
+      return execute_exceptionify(cli_cmd, options)
+    end
+
+    # we already know that auth is required
+    if class_variable_get(:@@cli_auth_required)
+      return execute_exceptionify(auth_cmd, options)
+    end
+
+    begin
+      # try first with no auth
+      return execute_exceptionify(cli_cmd, options)
+    rescue AuthError
+      # retry with auth
+      Puppet.debug("#{sname} cli auth failure -- retrying with ssh_private_key")
+      result = execute_exceptionify(auth_cmd, options)
+      class_variable_set(:@@cli_auth_required, true)
+      Puppet.debug("#{sname} cli_auth_required: #{class_variable_get(:@@cli_auth_required)}")
+      return result
+    end
+  end
+  private_class_method :execute_with_auth
+
+  # convert Puppet::ExecutionFailure into a ::AuthError exception if it appears
+  # that the command failure was due to an authication problem
+  def self.execute_exceptionify(*args)
+    cli_auth_errors = ['You must authenticate to access this Jenkins.',
+                       'anonymous is missing the Overall/Read permission',
+                       'anonymous is missing the Overall/RunScripts permission',
+                      ]
+    begin
+      #return Puppet::Provider.execute(*args)
+      return superclass.execute(*args)
+    rescue Puppet::ExecutionFailure => e
+      cli_auth_errors.each do |error|
+        if e.message.match(error)
+          raise AuthError, e.message, e.backtrace
+        end
+      end
+
+      raise UnknownError, e.message, e.backtrace
+    end
+  end
+  private_class_method :execute_exceptionify
+end

--- a/lib/puppet_x/jenkins/type.rb
+++ b/lib/puppet_x/jenkins/type.rb
@@ -1,0 +1,3 @@
+require 'puppet_x/jenkins'
+
+module PuppetX::Jenkins::Type; end

--- a/lib/puppet_x/jenkins/type/cli.rb
+++ b/lib/puppet_x/jenkins/type/cli.rb
@@ -1,0 +1,28 @@
+require 'puppet_x/jenkins/type'
+require 'puppet_x/jenkins/config'
+
+module PuppetX::Jenkins::Type::Cli
+  def self.newtype(*args, &block)
+    type = Puppet::Type.newtype(*args, &block)
+
+    # The jenkins master needs to be avaiable in order to interact with it via
+    # the cli jar.
+    type.autorequire(:service) do
+      ['jenkins']
+    end
+
+    # If a file resource is declared for file path params, make sure that it's
+    # converged so we can read it off disk.
+    type.autorequire(:file) do
+      config = PuppetX::Jenkins::Config.new(catalog)
+
+      autos = []
+      %w( ssh_private_key puppet_helper ).each do |param|
+        value = config[param.to_sym]
+        autos << value unless value.nil?
+      end
+
+      autos
+    end
+  end
+end

--- a/lib/puppet_x/jenkins/util.rb
+++ b/lib/puppet_x/jenkins/util.rb
@@ -1,0 +1,31 @@
+require 'puppet_x/jenkins'
+
+module PuppetX::Jenkins::Util
+  def unundef(data)
+    iterate(data) { |x| x == :undef ? nil : x }
+  end
+  module_function :unundef
+
+  def undefize(data)
+    iterate(data) { |x| x.nil? ? :undef : x }
+  end
+  module_function :undefize
+
+  # loosely based on
+  # https://stackoverflow.com/questions/16412013/iterate-nested-hash-that-contains-hash-and-or-array
+  def iterate(data, &block)
+    return data unless block_given?
+
+    case data
+    when Hash
+      data.each_with_object({}) do |(k,v), h|
+        h[k] = iterate(v, &block)
+      end
+    when Array
+      data.collect { |v| iterate(v, &block) }
+    else
+      block.call data
+    end
+  end
+  module_function :iterate
+end

--- a/manifests/cli/config.pp
+++ b/manifests/cli/config.pp
@@ -1,0 +1,50 @@
+# == Class: jenkins::cli::config
+#
+# This class provides configuration values to override defaults and fact data
+# for PuppetX::Jenkins::Provider::Clihelper based providers.
+#
+# Default and fact data is managed internal to the
+# PuppetX::Jenkins::Provider::Clihelper class for compatiblity with the puppet
+# resource face.  No defaults should be set in this classes definition.
+class jenkins::cli::config(
+  $cli_jar                 = undef,
+  $port                    = undef,
+  $ssh_private_key         = undef,
+  $puppet_helper           = undef,
+  $cli_tries               = undef,
+  $cli_try_sleep           = undef,
+  $ssh_private_key_content = undef,
+) {
+  if $cli_jar { validate_absolute_path($cli_jar) }
+  if $port { validate_integer($port) }
+  if $ssh_private_key { validate_absolute_path($ssh_private_key) }
+  if $puppet_helper { validate_absolute_path($puppet_helper) }
+  if $cli_tries { validate_integer($cli_tries) }
+  if $cli_try_sleep { validate_numeric($cli_try_sleep) }
+  validate_string($ssh_private_key_content)
+
+  # required by PuppetX::Jenkins::Provider::Clihelper base
+  package { 'retries':
+    provider => 'gem',
+  }
+
+  if $ssh_private_key and $ssh_private_key_content {
+    file { $ssh_private_key:
+      ensure  => 'file',
+      mode    => '0400',
+      backup  => false,
+      content => $ssh_private_key_content,
+    }
+
+    # allow this class to be included when not running as root
+    if $::id == 'root' {
+      File[$ssh_private_key] {
+        # the owner/group should probably be set externally and retrieved if
+        # present in the manfiest. At present, there is no authoritative place
+        # to retrive this information from.
+        owner => 'jenkins',
+        group => 'jenkins',
+      }
+    }
+  }
+}

--- a/spec/classes/cli/config_spec.rb
+++ b/spec/classes/cli/config_spec.rb
@@ -1,0 +1,147 @@
+require 'spec_helper'
+
+describe 'jenkins::cli::config', :type => :class do
+  shared_examples 'validate_absolute_path' do |param|
+    context 'absolute path' do
+      let(:params) {{ param => '/dne' }}
+      it { should_not raise_error }
+    end
+
+    context 'relative path' do
+      let(:params) {{ param => '../dne' }}
+      it 'should fail' do
+        should raise_error(Puppet::Error, /is not an absolute path/)
+      end
+    end
+  end # validate_absolute_path
+
+  shared_examples 'validate_integer' do |param|
+    context 'integer' do
+      let(:params) {{ param => 42 }}
+
+      it { should_not raise_error }
+    end
+
+    context 'string' do
+      let(:params) {{ param => 'foo' }}
+
+      it 'should fail' do
+        should raise_error(Puppet::Error, /to be an Integer/)
+      end
+    end
+  end # validate_integer
+
+  shared_examples 'validate_numeric' do |param|
+    context 'integer' do
+      let(:params) {{ param => 42 }}
+
+      it { should_not raise_error }
+    end
+
+    context 'float' do
+      let(:params) {{ param => 42.12345 }}
+
+      it { should_not raise_error }
+    end
+
+    context 'string' do
+      let(:params) {{ param => 'foo' }}
+
+      it 'should fail' do
+        should raise_error(Puppet::Error, /to be a Numeric/)
+      end
+    end
+  end # validate_numeric
+
+  shared_examples 'validate_string' do |param|
+    context 'string' do
+      let(:params) {{ param => 'foo' }}
+
+      it { should_not raise_error }
+    end
+
+    context 'array' do
+      let(:params) {{ param => [] }}
+
+      it 'should fail' do
+        should raise_error(Puppet::Error, /is not a string/)
+      end
+    end
+  end # validate_string
+
+  describe 'parameters' do
+    context 'accept all params undef' do
+      it { should_not raise_error }
+    end
+
+    describe 'cli_jar' do
+      it_behaves_like 'validate_absolute_path', :cli_jar
+    end
+
+    context 'port' do
+      it_behaves_like 'validate_integer', :port
+    end
+
+    context 'ssh_private_key' do
+      it_behaves_like 'validate_absolute_path', :ssh_private_key
+    end
+
+    context 'puppet_helper' do
+      it_behaves_like 'validate_absolute_path', :puppet_helper
+    end
+
+    context 'cli_tries' do
+      it_behaves_like 'validate_integer', :cli_tries
+    end
+
+    context 'cli_try_sleep' do
+      it_behaves_like 'validate_numeric', :cli_try_sleep
+    end
+
+    context 'ssh_private_key_content' do
+      it_behaves_like 'validate_string', :ssh_private_key_content
+
+      context 'when ssh_private_key is also set' do
+        let(:params) do
+          {
+            :ssh_private_key         => '/dne',
+            :ssh_private_key_content => 'foo',
+          }
+        end
+
+        context 'as non-root user' do
+          let(:facts) {{ :id => 'user' }}
+
+          it do
+            should contain_file('/dne').with(
+              :ensure => 'file',
+              :mode   => '0400',
+              :backup => false,
+              :owner  => nil,
+              :group  => nil,
+            )
+          end
+          it { should contain_file('/dne').with_content('foo') }
+        end # as non-root user
+
+        context 'as root' do
+          let(:facts) {{ :id => 'root' }}
+
+          it do
+            should contain_file('/dne').with(
+              :ensure => 'file',
+              :mode   => '0400',
+              :backup => false,
+              :owner  => 'jenkins',
+              :group  => 'jenkins',
+            )
+          end
+          it { should contain_file('/dne').with_content('foo') }
+        end # as root
+      end # when ssh_private_key is also set
+    end # ssh_private_key_content
+  end # parameters
+
+  it { should contain_package('retries').with(:provider => 'gem') }
+
+end

--- a/spec/unit/puppet/provider/jenkins_authorization_strategy/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_authorization_strategy/cli_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+require 'json'
+
+describe Puppet::Type.type(:jenkins_authorization_strategy).provider(:cli) do
+  let(:strategy_oauth_json) do
+    <<-EOS
+      {
+          "setAuthorizationStrategy": {
+              "org.jenkinsci.plugins.GithubAuthorizationStrategy": [
+                  "jhoblitt, dne",
+                  false,
+                  false,
+                  false,
+                  "lsst, sqre-test",
+                  false,
+                  false,
+                  false
+              ]
+          }
+      }
+    EOS
+  end
+  let(:strategy_oauth) { JSON.parse(strategy_oauth_json) }
+
+  let(:strategy_unsecured_json) do
+    <<-EOS
+      {
+          "setAuthorizationStrategy": {
+              "hudson.security.AuthorizationStrategy$Unsecured": [
+
+              ]
+          }
+      }
+    EOS
+  end
+  let(:strategy_unsecured) { JSON.parse(strategy_unsecured_json) }
+
+  shared_examples "a provider from example strategy" do
+    it do
+      method_name = 'setAuthorizationStrategy'
+      class_name = info[method_name].keys.first
+      ctor_args = info[method_name][class_name]
+
+      expect(provider.name).to eq class_name
+      expect(provider.ensure).to eq :present
+      expect(provider.arguments).to eq ctor_args
+    end
+  end
+
+  describe "::instances" do
+    context "without any params" do
+      before do
+        expect(described_class).to receive(:get_authorization_strategy).
+          with(nil) { strategy_oauth }
+      end
+
+      it "should return the correct number of instances" do
+        expect(described_class.instances.size).to eq 1
+      end
+
+      context "first instance returned" do
+        it_behaves_like "a provider from example strategy" do
+          let(:info) { strategy_oauth }
+          let(:provider) { described_class.instances[0] }
+        end
+      end
+    end
+
+    context "when called with a catalog param" do
+      it "should pass it on ::get_authorization_strategy" do
+        catalog = Puppet::Resource::Catalog.new
+
+        expect(described_class).to receive(:get_authorization_strategy).
+          with(catalog) { strategy_oauth }
+
+        described_class.instances(catalog)
+      end
+    end
+  end # ::instanes
+
+  describe '#flush' do
+    it 'should call set_jenkins_instance' do
+      provider = described_class.new
+      provider.create
+
+      expect(provider).to receive(:set_jenkins_instance)
+      provider.flush
+    end
+
+    it 'should call set_strategy_unsecured' do
+      provider = described_class.new
+      provider.destroy
+
+      expect(provider).to receive(:set_strategy_unsecured)
+      provider.flush
+    end
+
+    it 'should call set_strategy_unsecured' do
+      provider = described_class.new
+
+      expect(provider).to receive(:set_strategy_unsecured)
+      provider.flush
+    end
+  end # #flush
+
+  #
+  # private methods
+  #
+
+  describe '::from_hash' do
+    it_behaves_like "a provider from example strategy" do
+      let(:info) { strategy_oauth }
+      let(:provider) { described_class.send(:from_hash, info) }
+    end
+
+    it_behaves_like "a provider from example strategy" do
+      let(:info) { strategy_unsecured }
+      let(:provider) { described_class.send(:from_hash, info) }
+    end
+  end # ::from_hash
+
+  describe '::to_hash' do
+    # not isolated from ::from_hash in the interests of staying DRY
+    it do
+      provider = described_class.send :from_hash, strategy_oauth
+      info = provider.send :to_hash
+
+      expect(info).to eq strategy_oauth
+    end
+  end # ::to_hash
+
+  describe '::get_authorization_strategy' do
+    it do
+      expect(described_class).to receive(:clihelper).with(
+        ['get_authorization_strategy'],
+        {:catalog => nil},
+      ) { strategy_oauth_json }
+
+      raw = described_class.send :get_authorization_strategy
+      expect(raw).to eq strategy_oauth
+    end
+  end # ::get_authorization_strategy
+
+  describe '#set_jenkins_instance' do
+    it do
+      provider = described_class.send :from_hash, strategy_oauth
+
+      expect(described_class).to receive(:clihelper).with(
+        ['set_jenkins_instance'],
+        { :stdinjson => strategy_oauth },
+      )
+
+      provider.send :set_jenkins_instance
+    end
+  end # #set_jenkins_instance
+
+  describe '#set_strategy_unsecured' do
+    it do
+      provider = described_class.new(:name => 'test')
+
+      expect(described_class).to receive(:clihelper).with(
+        ['set_jenkins_instance'],
+        { :stdinjson => strategy_unsecured },
+      )
+
+      provider.send :set_strategy_unsecured
+    end
+  end # #set_security_none
+end

--- a/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
@@ -1,0 +1,222 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_providers'
+
+require 'json'
+
+describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
+  let(:credentials_list_json_raw) do
+    <<-EOS
+    [
+        {
+            "id": "9b07d668-a87e-4877-9407-ae05056e32ac",
+            "domain": null,
+            "scope": "GLOBAL",
+            "impl": "UsernamePasswordCredentialsImpl",
+            "description": "foo",
+            "username": "batman",
+            "password": "password"
+        },
+        {
+            "id": "14dbba6e-fc00-4102-ae97-7a178058f91b",
+            "domain": null,
+            "scope": "SYSTEM",
+            "impl": "BasicSSHUserPrivateKey",
+            "description": "bar",
+            "private_key": "-----BEGIN RSA PRIVATE KEY-----",
+            "passphrase": ""
+        }
+    ]
+    EOS
+  end
+  let(:credentials) { JSON.parse(credentials_list_json_raw) }
+
+  shared_examples "a provider from example hash 1" do
+    it do
+      cred = credentials[0]
+
+      expect(provider.name).to eq cred['id']
+      expect(provider.ensure).to eq :present
+      [
+        'domain',
+        'scope',
+        'impl',
+        'description',
+        'username',
+        'password',
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq cred[k].nil? ? :undef : cred[k]
+      end
+
+      [
+        'private_key',
+        'passphrase',
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq :absent
+      end
+    end
+  end
+
+  shared_examples "a provider from example hash 2" do
+    it do
+      cred = credentials[1]
+
+      expect(provider.name).to eq cred['id']
+      expect(provider.ensure).to eq :present
+      [
+        'domain',
+        'scope',
+        'impl',
+        'description',
+        'private_key',
+        'passphrase',
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq cred[k].nil? ? :undef : cred[k]
+      end
+
+      [
+        'username',
+        'password',
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq :absent
+      end
+
+    end
+  end
+
+  include_examples 'confines to cli dependencies'
+
+  describe "::instances" do
+    context "without any params" do
+      before do
+        expect(described_class).to receive(:credentials_list_json).
+          with(nil) { credentials }
+      end
+
+      it "should return the correct number of instances" do
+        expect(described_class.instances.size).to eq 2
+      end
+
+      context "first instance returned" do
+        it_behaves_like "a provider from example hash 1" do
+          let(:provider) do
+            described_class.instances[0]
+          end
+        end
+      end
+
+      context "second instance returned" do
+        it_behaves_like "a provider from example hash 2" do
+          let(:provider) do
+            described_class.instances[1]
+          end
+        end
+      end
+    end
+
+    context "when called with a catalog param" do
+      it "should pass it on ::credentials_list_json" do
+        catalog = Puppet::Resource::Catalog.new
+
+        expect(described_class).to receive(:credentials_list_json).
+          with(kind_of(Puppet::Resource::Catalog)) { credentials }
+
+        described_class.instances(catalog)
+      end
+    end
+  end # ::instanes
+
+  describe '#flush' do
+    it 'should call credentials_update' do
+      provider = described_class.new
+      provider.create
+
+      expect(provider).to receive(:credentials_update_json)
+      provider.flush
+    end
+
+    it 'should call credentials_delete_id' do
+      provider = described_class.new
+      provider.destroy
+
+      expect(provider).to receive(:credentials_delete_id)
+      provider.flush
+    end
+
+    it 'should call credentials_delete_id' do
+      provider = described_class.new
+
+      expect(provider).to receive(:credentials_delete_id)
+      provider.flush
+    end
+  end # #flush
+
+  #
+  # private methods
+  #
+
+  describe '::from_hash' do
+    it_behaves_like "a provider from example hash 1" do
+      let(:provider) do
+        described_class.send :from_hash, credentials[0]
+      end
+    end
+
+    it_behaves_like "a provider from example hash 2" do
+      let(:provider) do
+        described_class.send :from_hash, credentials[1]
+      end
+    end
+  end # ::from_hash
+
+  describe '::to_hash' do
+    # not isolated from ::from_hash in the interests of staying DRY
+    it do
+      provider = described_class.send :from_hash, credentials[0]
+      info = provider.send :to_hash
+
+      expect(info).to eq credentials[0]
+    end
+  end # ::to_hash
+
+  describe '::credentials_list_json' do
+    # not isolated from ::from_hash in the interests of staying DRY
+    it do
+      expect(described_class).to receive(:clihelper).with(
+        ['credentials_list_json'],
+        {:catalog => nil}
+      ) { JSON.pretty_generate(credentials[0]) }
+
+      raw = described_class.send :credentials_list_json
+      expect(raw).to eq credentials[0]
+    end
+  end # ::credentials_list_json
+
+  describe '#credentials_update_json' do
+    RSpec::Matchers.define :a_json_doc do |x|
+      match { |actual| JSON.parse(actual) == x }
+    end
+
+    it do
+      provider = described_class.send :from_hash, credentials[0]
+
+      expect(described_class).to receive(:clihelper).with(
+        ['credentials_update_json'],
+        {:stdinjson => credentials[0]},
+      )
+
+      provider.send :credentials_update_json
+    end
+  end # #credentials_update_json
+
+  describe '#credentials_delete_id' do
+    it do
+      provider = described_class.send :from_hash, credentials[0]
+
+      expect(described_class).to receive(:clihelper).with(
+        ['credentials_delete_id', '9b07d668-a87e-4877-9407-ae05056e32ac']
+      )
+
+      provider.send :credentials_delete_id
+    end
+  end # #credentials_delete_id
+end

--- a/spec/unit/puppet/provider/jenkins_job/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_job/cli_spec.rb
@@ -1,0 +1,222 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_providers'
+
+describe Puppet::Type.type(:jenkins_job).provider(:cli) do
+  let(:list_jobs_output) { "foo\nbar\n" }
+  let(:foo_xml) do
+    <<-EOS
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <actions/>
+  <description/>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.25">
+      <autoRebuild>false</autoRebuild>
+      <rebuildDisabled>false</rebuildDisabled>
+    </com.sonyericsson.rebuild.RebuildSettings>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>
+    EOS
+  end
+  let(:bar_xml) do
+    foo_xml.sub('<disabled>false</disabled>', '<disabled>true</disabled>')
+  end
+
+  include_examples 'confines to cli dependencies'
+
+  describe "::instances" do
+    context "without any params" do
+      before do
+        expect(described_class).to receive(:list_jobs).
+          with(nil) { ['foo', 'bar']}
+
+        expect(described_class).to receive(:get_job).
+          with('foo', nil) { foo_xml }
+
+        expect(described_class).to receive(:job_enabled).
+          with('foo', nil) { true }
+
+        expect(described_class).to receive(:get_job).
+          with('bar', nil) { bar_xml }
+
+        expect(described_class).to receive(:job_enabled).
+          with('bar', nil) { false }
+      end
+
+      it "should return the correct number of instances" do
+        expect(described_class.instances.size).to eq 2
+      end
+
+      context "first instance returned" do
+        let(:provider) do
+          described_class.instances[0]
+        end
+
+        it { expect(provider.name).to eq 'foo' }
+        it { expect(provider.config).to eq foo_xml }
+        it { expect(provider.enable).to eq true }
+      end
+
+      context "second instance returned" do
+        let(:provider) do
+          described_class.instances[1]
+        end
+
+        it { expect(provider.name).to eq 'bar' }
+        it { expect(provider.config).to eq bar_xml }
+        it { expect(provider.enable).to eq false }
+      end
+    end
+
+    context "when called with a catalog param" do
+      it "should pass it on ::list_jobs, ::get_job, & ::job_enabled" do
+        catalog = Puppet::Resource::Catalog.new
+
+        expect(described_class).to receive(:list_jobs).
+          with(kind_of(Puppet::Resource::Catalog)) { ['foo'] }
+
+        expect(described_class).to receive(:get_job).
+          with('foo', kind_of(Puppet::Resource::Catalog))
+
+        expect(described_class).to receive(:job_enabled).
+          with('foo', kind_of(Puppet::Resource::Catalog))
+
+        described_class.instances(catalog)
+      end
+    end
+  end # ::instanes
+
+  describe '#create' do
+    it 'should do nothing' do
+      provider = described_class.new
+      expect(provider.ensure).to eq :absent
+      provider.create
+      expect(provider.ensure).to eq :absent
+    end
+  end # #create
+
+  describe '#flush' do
+    it 'should call create_job' do
+      provider = described_class.new
+      provider.ensure = :present
+
+      expect(provider).to receive(:exists?) { false }
+      expect(provider).to receive(:create_job)
+      provider.flush
+    end
+
+    it 'should call update_job' do
+      provider = described_class.new
+      provider.ensure = :present
+
+      expect(provider).to receive(:exists?) { true }
+      expect(provider).to receive(:update_job)
+      provider.flush
+    end
+
+    it 'should call delete_job' do
+      provider = described_class.new
+      provider.destroy
+
+      expect(provider).to receive(:delete_job)
+      provider.flush
+    end
+  end # #flush
+
+  #
+  # private methods
+  #
+
+  describe '::list_jobs' do
+    it do
+      expect(described_class).to receive(:cli).with(
+        ['list-jobs'],
+        {:catalog => nil}
+      ) { list_jobs_output }
+
+      ret = described_class.send :list_jobs
+      expect(ret).to eq ['foo', 'bar']
+    end
+  end # ::list_jobs
+
+  describe '::get_job' do
+    it do
+      expect(described_class).to receive(:cli).with(
+        ['get-job', 'foo'],
+        {:catalog => nil}
+      ) { foo_xml }
+
+      ret = described_class.send :get_job, 'foo'
+      expect(ret).to eq foo_xml
+    end
+  end # ::get_job
+
+  describe '::job_enabled' do
+    it do
+      expect(described_class).to receive(:clihelper).with(
+        ['job_enabled', 'foo'],
+        {:catalog => nil}
+      ) { 'true' }
+
+      ret = described_class.send :job_enabled, 'foo'
+      expect(ret).to eq true
+    end
+  end # ::job_enabled
+
+  describe '#create_job' do
+    it do
+      provider = described_class.new(
+        :name   => 'foo',
+        :config => foo_xml,
+      )
+
+      expect(described_class).to receive(:cli).with(
+        ['create-job', 'foo'],
+        {:stdin => foo_xml}
+      )
+
+      provider.send :create_job
+    end
+  end # #create_job
+
+  describe '#update_job' do
+    it do
+      provider = described_class.new(
+        :name   => 'foo',
+        :config => foo_xml,
+      )
+
+      expect(described_class).to receive(:cli).with(
+        ['update-job', 'foo'],
+        {:stdin => foo_xml}
+      )
+
+      provider.send :update_job
+    end
+  end # #update_job
+
+  describe '#delete_job' do
+    it do
+      provider = described_class.new(
+        :name   => 'foo',
+        :config => foo_xml,
+      )
+
+      expect(described_class).to receive(:cli).with(
+        ['delete-job', 'foo']
+      )
+
+      provider.send :delete_job
+    end
+  end # #delete_job
+end

--- a/spec/unit/puppet/provider/jenkins_num_executors/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_num_executors/cli_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'json'
+
+describe Puppet::Type.type(:jenkins_num_executors).provider(:cli) do
+  describe "::instances" do
+    context "without any params" do
+      before do
+        expect(described_class).to receive(:get_num_executors).
+          with(nil) { 42 }
+      end
+
+      it "should return the correct number of instances" do
+        expect(described_class.instances.size).to eq 1
+      end
+
+      context "first instance returned" do
+        let(:provider) { described_class.instances[0] }
+
+        it { expect(provider.name).to eq 42 }
+      end
+    end
+
+    context "when called with a catalog param" do
+      it "should pass it on ::get_num_executors" do
+        catalog = Puppet::Resource::Catalog.new
+
+        expect(described_class).to receive(:get_num_executors).
+          with(catalog) { 42 }
+
+        described_class.instances(catalog)
+      end
+    end
+  end # ::instanes
+
+  describe '#flush' do
+    it 'should call set_num_executors' do
+      provider = described_class.new
+      provider.create
+
+      expect(provider).to receive(:set_num_executors).with(no_args)
+      provider.flush
+    end
+
+    it 'should fail' do
+      provider = described_class.new
+      provider.destroy
+
+      expect { provider.flush }.
+        to raise_error(Puppet::Error, /invalid :ensure value: absent/)
+    end
+  end # #flush
+
+
+  #
+  # private methods
+  #
+
+  describe '::get_num_executors' do
+    it do
+      expect(described_class).to receive(:clihelper).
+        with(['get_num_executors'], :catalog => nil) { 42 }
+
+      n = described_class.send :get_num_executors
+      expect(n).to eq 42
+    end
+  end # ::get_num_executors
+
+  describe '#set_jenkins_instance' do
+    it do
+      provider = described_class.new(:name => 42)
+
+      expect(described_class).to receive(:clihelper).with(['set_num_executors', 42])
+
+      provider.send :set_num_executors
+    end
+  end # #set_jenkins_instance
+
+end

--- a/spec/unit/puppet/provider/jenkins_security_realm/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_security_realm/cli_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+require 'json'
+
+describe Puppet::Type.type(:jenkins_security_realm).provider(:cli) do
+  let(:realm_oauth_json) do
+    <<-EOS
+      {
+          "setSecurityRealm": {
+              "org.jenkinsci.plugins.GithubSecurityRealm": [
+                  "https://github.com",
+                  "https://api.github.com",
+                  "42",
+                  "43",
+                  "read:org"
+              ]
+          }
+      }
+    EOS
+  end
+  let(:realm_oauth) { JSON.parse(realm_oauth_json) }
+
+  let(:realm_none_json) do
+    <<-EOS
+      {
+          "setSecurityRealm": {
+              "hudson.security.SecurityRealm$None": [
+
+              ]
+          }
+      }
+    EOS
+  end
+  let(:realm_none) { JSON.parse(realm_none_json) }
+
+  shared_examples "a provider from example realm" do
+    it do
+      method_name = 'setSecurityRealm'
+      class_name = info[method_name].keys.first
+      ctor_args = info[method_name][class_name]
+
+      expect(provider.name).to eq class_name
+      expect(provider.ensure).to eq :present
+      expect(provider.arguments).to eq ctor_args
+    end
+  end
+
+  describe "::instances" do
+    context "without any params" do
+      before do
+        expect(described_class).to receive(:get_security_realm).
+          with(nil) { realm_oauth }
+      end
+
+      it "should return the correct number of instances" do
+        expect(described_class.instances.size).to eq 1
+      end
+
+      context "first instance returned" do
+        it_behaves_like "a provider from example realm" do
+          let(:info) { realm_oauth }
+          let(:provider) { described_class.instances[0] }
+        end
+      end
+    end
+
+    context "when called with a catalog param" do
+      it "should pass it on ::get_security_realm" do
+        catalog = Puppet::Resource::Catalog.new
+
+        expect(described_class).to receive(:get_security_realm).
+          with(catalog) { realm_oauth }
+
+        described_class.instances(catalog)
+      end
+    end
+  end # ::instanes
+
+  describe '#flush' do
+    it 'should call set_jenkins_instance' do
+      provider = described_class.new
+      provider.create
+
+      expect(provider).to receive(:set_jenkins_instance)
+      provider.flush
+    end
+
+    it 'should call set_security_none' do
+      provider = described_class.new
+      provider.destroy
+
+      expect(provider).to receive(:set_security_none)
+      provider.flush
+    end
+
+    it 'should call set_security_none' do
+      provider = described_class.new
+
+      expect(provider).to receive(:set_security_none)
+      provider.flush
+    end
+  end # #flush
+
+  #
+  # private methods
+  #
+
+  describe '::from_hash' do
+    it_behaves_like "a provider from example realm" do
+      let(:info) { realm_oauth }
+      let(:provider) { described_class.send(:from_hash, info) }
+    end
+
+    it_behaves_like "a provider from example realm" do
+      let(:info) { realm_none }
+      let(:provider) { described_class.send(:from_hash, info) }
+    end
+  end # ::from_hash
+
+  describe '::to_hash' do
+    # not isolated from ::from_hash in the interests of staying DRY
+    it do
+      provider = described_class.send :from_hash, realm_oauth
+      info = provider.send :to_hash
+
+      expect(info).to eq realm_oauth
+    end
+  end # ::to_hash
+
+  describe '::get_security_realm' do
+    # not isolated from ::from_hash in the interests of staying DRY
+    it do
+      expect(described_class).to receive(:clihelper).with(
+        ['get_security_realm'],
+        {:catalog => nil}
+      ) { realm_oauth_json }
+
+      raw = described_class.send :get_security_realm
+      expect(raw).to eq realm_oauth
+    end
+  end # ::get_security_realm
+
+  describe '#set_jenkins_instance' do
+    it do
+      provider = described_class.send :from_hash, realm_oauth
+
+      expect(described_class).to receive(:clihelper).with(
+        ['set_jenkins_instance'],
+        { :stdinjson => realm_oauth },
+      )
+
+      provider.send :set_jenkins_instance
+    end
+  end # #set_jenkins_instance
+
+  describe '#set_security_none' do
+    it do
+      provider = described_class.new(:name => 'test')
+
+      expect(described_class).to receive(:clihelper).with(
+        ['set_jenkins_instance'],
+        { :stdinjson => realm_none },
+      )
+
+      provider.send :set_security_none
+    end
+  end # #set_security_none
+end

--- a/spec/unit/puppet/provider/jenkins_slaveagent_port/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_slaveagent_port/cli_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'json'
+
+describe Puppet::Type.type(:jenkins_slaveagent_port).provider(:cli) do
+  describe "::instances" do
+    context "without any params" do
+      before do
+        expect(described_class).to receive(:get_slaveagent_port).
+          with(nil) { 42 }
+      end
+
+      it "should return the correct number of instances" do
+        expect(described_class.instances.size).to eq 1
+      end
+
+      context "first instance returned" do
+        let(:provider) { described_class.instances[0] }
+
+        it { expect(provider.name).to eq 42 }
+      end
+    end
+
+    context "when called with a catalog param" do
+      it "should pass it on ::get_slaveagent_port" do
+        catalog = Puppet::Resource::Catalog.new
+
+        expect(described_class).to receive(:get_slaveagent_port).
+          with(catalog) { 42 }
+
+        described_class.instances(catalog)
+      end
+    end
+  end # ::instanes
+
+  describe '#flush' do
+    it 'should call set_slaveagent_port' do
+      provider = described_class.new
+      provider.create
+
+      expect(provider).to receive(:set_slaveagent_port).with(no_args)
+      provider.flush
+    end
+
+    it 'should fail' do
+      provider = described_class.new
+      provider.destroy
+
+      expect { provider.flush }.
+        to raise_error(Puppet::Error, /invalid :ensure value: absent/)
+    end
+  end # #flush
+
+
+  #
+  # private methods
+  #
+
+  describe '::get_slaveagent_port' do
+    it do
+      expect(described_class).to receive(:clihelper).
+        with(['get_slaveagent_port'], :catalog => nil) { 42 }
+
+      n = described_class.send :get_slaveagent_port
+      expect(n).to eq 42
+    end
+  end # ::get_slaveagent_port
+
+  describe '#set_jenkins_instance' do
+    it do
+      provider = described_class.new(:name => 42)
+
+      expect(described_class).to receive(:clihelper).with(['set_slaveagent_port', 42])
+
+      provider.send :set_slaveagent_port
+    end
+  end # #set_jenkins_instance
+
+end

--- a/spec/unit/puppet/provider/jenkins_user/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_user/cli_spec.rb
@@ -1,0 +1,202 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_providers'
+
+require 'json'
+
+describe Puppet::Type.type(:jenkins_user).provider(:cli) do
+  let(:user_info_json) do
+    <<-EOS
+      [
+        {
+
+          "id": "test",
+          "full_name": "test",
+          "email_address": "foo@foo.org",
+          "public_keys": ["ssh-rsa foo com", "ssh-rsa bar com"],
+          "api_token_public": "b0da1e0bf3f79ff02624c2f716913808",
+          "api_token_plain": "51a8b1dd95bc76b1a2869356c043e8b9",
+          "password": "#jbcrypt:$2a$10$dg5kqB/bNVgotE0alN.V5OQJ1BajkmM2ZOFAmtlSt29bB4xEDZOja"
+        },
+        {
+          "id": "guest"
+        }
+      ]
+    EOS
+  end
+  let(:user_info) { JSON.parse(user_info_json) }
+  let(:mutable_user_info) do
+    # we should not be trying to flush the api_token_public value as it is
+    # immutable
+    info = user_info[0]
+    info.delete('api_token_public')
+    info
+  end
+
+  shared_examples "a provider from example hash 1" do
+    it do
+      expect(provider.name).to eq user_info[0]['id']
+      expect(provider.ensure).to eq :present
+      expect(provider.full_name).to eq user_info[0]['full_name']
+      expect(provider.email_address).to eq user_info[0]['email_address']
+      expect(provider.public_keys).to eq user_info[0]['public_keys']
+      expect(provider.api_token_public).to eq user_info[0]['api_token_public']
+      expect(provider.api_token_plain).to eq user_info[0]['api_token_plain']
+      expect(provider.password).to eq user_info[0]['password']
+    end
+  end
+
+  shared_examples "a provider from example hash 2" do
+    it do
+      expect(provider.name).to eq user_info[1]['id']
+      expect(provider.ensure).to eq :present
+      expect(provider.full_name).to eq :absent
+      expect(provider.email_address).to eq :absent
+      expect(provider.public_keys).to eq :absent
+      expect(provider.api_token_public).to eq :absent
+      expect(provider.api_token_plain).to eq :absent
+      expect(provider.password).to eq :absent
+    end
+  end
+
+  include_examples 'confines to cli dependencies'
+
+  describe "::instances" do
+    context "without any params" do
+      before do
+        expect(described_class).to receive(:user_info_all).
+          with(nil) { user_info }
+      end
+
+      it "should return the correct number of instances" do
+        expect(described_class.instances.size).to eq 2
+      end
+
+      context "first instance returned" do
+        it_behaves_like "a provider from example hash 1" do
+          let(:provider) do
+            described_class.instances[0]
+          end
+        end
+      end
+
+      context "second instance returned" do
+        it_behaves_like "a provider from example hash 2" do
+          let(:provider) do
+            described_class.instances[1]
+          end
+        end
+      end
+    end
+
+    context "when called with a catalog param" do
+      it "should pass it on ::user_info_all" do
+        catalog = Puppet::Resource::Catalog.new
+
+        expect(described_class).to receive(:user_info_all).
+          with(catalog) { user_info }
+
+        described_class.instances(catalog)
+      end
+    end
+  end # ::instanes
+
+  describe '#api_token_public=' do
+    it 'should be read only (fail)' do
+      provider = described_class.new
+
+      expect { provider.api_token_public = 'foo' }.to raise_error(Puppet::Error, /api_token_pubilc is read-only/)
+    end
+  end # #api_token_public=
+
+  describe '#flush' do
+    it 'should call user_update' do
+      provider = described_class.new
+      provider.create
+
+      expect(provider).to receive(:user_update)
+      provider.flush
+    end
+
+    it 'should call delete_user' do
+      provider = described_class.new
+      provider.destroy
+
+      expect(provider).to receive(:delete_user)
+      provider.flush
+    end
+
+    it 'should call delete_user' do
+      provider = described_class.new
+
+      expect(provider).to receive(:delete_user)
+      provider.flush
+    end
+  end # #flush
+
+  #
+  # private methods
+  #
+
+  describe '::from_hash' do
+    it_behaves_like "a provider from example hash 1" do
+      let(:provider) do
+        described_class.send :from_hash, user_info[0]
+      end
+    end
+
+    it_behaves_like "a provider from example hash 2" do
+      let(:provider) do
+        described_class.send :from_hash, user_info[1]
+      end
+    end
+  end # ::from_hash
+
+  describe '::to_hash' do
+    # not isolated from ::from_hash in the interests of staying DRY
+    it do
+      provider = described_class.send :from_hash, user_info[0]
+      info = provider.send :to_hash
+
+      expect(info).to eq mutable_user_info
+    end
+  end # ::to_hash
+
+  describe '::user_info_all' do
+    # not isolated from ::from_hash in the interests of staying DRY
+    it do
+      expect(described_class).to receive(:clihelper).with(['user_info_all']) { user_info_json }
+
+      raw = described_class.send :user_info_all
+      expect(raw).to eq user_info
+    end
+  end # ::user_info_all
+
+  describe '#user_update' do
+    RSpec::Matchers.define :a_json_doc do |x|
+      match { |actual| JSON.parse(actual) == x }
+    end
+
+    it do
+      provider = described_class.send :from_hash, user_info[0]
+
+      expect(described_class).to receive(:clihelper).with(
+        ['user_update'],
+        { :stdinjson => mutable_user_info },
+      )
+
+      provider.send :user_update
+    end
+  end # #user_update
+
+  describe '#delete_user' do
+    it do
+      provider = described_class.send :from_hash, user_info[0]
+
+      expect(described_class).to receive(:clihelper).with(
+        ['delete_user', 'test']
+      )
+
+      provider.send :delete_user
+    end
+  end # #delete_update
+end

--- a/spec/unit/puppet/type/jenkins_authorization_strategy_spec.rb
+++ b/spec/unit/puppet/type/jenkins_authorization_strategy_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_types'
+
+describe Puppet::Type.type(:jenkins_authorization_strategy) do
+  before(:each) { Facter.clear }
+
+  describe 'parameters' do
+    describe 'name' do
+      it_behaves_like 'generic namevar', :name
+    end
+  end # parameters
+
+  describe 'properties' do
+    describe 'ensure' do
+      it_behaves_like 'generic ensurable'
+    end
+
+    describe 'arguments' do
+      it_behaves_like 'array_matching property'
+    end
+  end # properties
+
+  describe 'autorequire' do
+    it_behaves_like 'autorequires cli resources'
+    it_behaves_like 'autorequires all jenkins_user resources'
+    it_behaves_like 'autorequires jenkins_security_realm resource'
+  end
+end

--- a/spec/unit/puppet/type/jenkins_credentials_spec.rb
+++ b/spec/unit/puppet/type/jenkins_credentials_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_types'
+
+describe Puppet::Type.type(:jenkins_credentials) do
+  before(:each) { Facter.clear }
+
+  describe 'parameters' do
+    describe 'name' do
+      it_behaves_like 'generic namevar', :name
+    end
+  end #parameters
+
+  describe 'properties' do
+    describe 'ensure' do
+      it_behaves_like 'generic ensurable'
+    end
+
+    describe 'domain' do
+      it_behaves_like 'validated property', :domain, :undef, [:undef]
+    end
+
+    describe 'scope' do
+      it_behaves_like 'validated property', :scope, :GLOBAL, [:GLOBAL, :SYSTEM]
+    end
+
+    describe 'impl' do
+      it_behaves_like 'validated property', :impl,
+        :UsernamePasswordCredentialsImpl,
+        [
+          :UsernamePasswordCredentialsImpl,
+          :BasicSSHUserPrivateKey
+        ]
+    end
+
+    # unvalidated properties
+    [
+      :description,
+      :username,
+      :password,
+      :private_key,
+      :passphrase,
+      :secret,
+      :file_name,
+      :content,
+      :source,
+      :key_store_impl
+    ].each do |property|
+      describe "#{property}" do
+        context 'attrtype' do
+          it { expect(described_class.attrtype(property)).to eq :property }
+        end
+      end
+    end
+  end #properties
+
+  describe 'autorequire' do
+    it_behaves_like 'autorequires cli resources'
+    it_behaves_like 'autorequires all jenkins_user resources'
+    it_behaves_like 'autorequires jenkins_security_realm resource'
+    it_behaves_like 'autorequires jenkins_authorization_strategy resource'
+  end
+end

--- a/spec/unit/puppet/type/jenkins_job_spec.rb
+++ b/spec/unit/puppet/type/jenkins_job_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_types'
+
+describe Puppet::Type.type(:jenkins_job) do
+  before(:each) { Facter.clear }
+
+  describe 'parameters' do
+    describe 'name' do
+      it_behaves_like 'generic namevar', :name
+    end
+  end #parameters
+
+  describe 'properties' do
+    describe 'ensure' do
+      it_behaves_like 'generic ensurable'
+    end
+
+    describe 'enable' do
+      it_behaves_like 'boolean property', :enable, true
+    end
+
+    # unvalidated properties
+    [:config].each do |property|
+      describe "#{property}" do
+        it { expect(described_class.attrtype(property)).to eq :property }
+      end
+    end
+  end #properties
+
+  describe 'autorequire' do
+    it_behaves_like 'autorequires cli resources'
+    it_behaves_like 'autorequires all jenkins_user resources'
+    it_behaves_like 'autorequires jenkins_security_realm resource'
+    it_behaves_like 'autorequires jenkins_authorization_strategy resource'
+  end
+end

--- a/spec/unit/puppet/type/jenkins_num_executors_spec.rb
+++ b/spec/unit/puppet/type/jenkins_num_executors_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_types'
+
+describe Puppet::Type.type(:jenkins_num_executors) do
+  before(:each) { Facter.clear }
+
+  describe 'parameters' do
+    describe 'name' do
+      it_behaves_like 'generic namevar', :name
+    end
+  end #parameters
+
+  describe 'properties' do
+    describe 'ensure' do
+      it_behaves_like 'generic ensurable', :present
+    end
+  end # properties
+
+  describe 'autorequire' do
+    it_behaves_like 'autorequires cli resources'
+    it_behaves_like 'autorequires all jenkins_user resources'
+    it_behaves_like 'autorequires jenkins_security_realm resource'
+    it_behaves_like 'autorequires jenkins_authorization_strategy resource'
+  end
+end

--- a/spec/unit/puppet/type/jenkins_security_realm_spec.rb
+++ b/spec/unit/puppet/type/jenkins_security_realm_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_types'
+
+describe Puppet::Type.type(:jenkins_security_realm) do
+  before(:each) { Facter.clear }
+
+  describe 'parameters' do
+    describe 'name' do
+      it_behaves_like 'generic namevar', :name
+    end
+  end #parameters
+
+  describe 'properties' do
+    describe 'ensure' do
+      it_behaves_like 'generic ensurable'
+    end
+
+    describe 'arguments' do
+      it_behaves_like 'array_matching property'
+    end
+  end #properties
+
+  describe 'autorequire' do
+    it_behaves_like 'autorequires cli resources'
+    it_behaves_like 'autorequires all jenkins_user resources'
+  end
+end

--- a/spec/unit/puppet/type/jenkins_slaveagent_port_spec.rb
+++ b/spec/unit/puppet/type/jenkins_slaveagent_port_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_types'
+
+describe Puppet::Type.type(:jenkins_slaveagent_port) do
+  before(:each) { Facter.clear }
+
+  describe 'parameters' do
+    describe 'name' do
+      it_behaves_like 'generic namevar', :name
+    end
+  end #parameters
+
+  describe 'properties' do
+    describe 'ensure' do
+      it_behaves_like 'generic ensurable', :present
+    end
+  end # properties
+
+  describe 'autorequire' do
+    it_behaves_like 'autorequires cli resources'
+    it_behaves_like 'autorequires all jenkins_user resources'
+    it_behaves_like 'autorequires jenkins_security_realm resource'
+    it_behaves_like 'autorequires jenkins_authorization_strategy resource'
+  end
+end

--- a/spec/unit/puppet/type/jenkins_user_spec.rb
+++ b/spec/unit/puppet/type/jenkins_user_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_types'
+
+describe Puppet::Type.type(:jenkins_user) do
+  before(:each) { Facter.clear }
+
+  describe 'parameters' do
+    describe 'name' do
+      it_behaves_like 'generic namevar', :name
+    end
+  end #parameters
+
+  describe 'properties' do
+    describe 'ensure' do
+      it_behaves_like 'generic ensurable'
+    end
+
+    # unvalidated properties
+    [:full_name, :email_address,
+     :api_token_public, :password].each do |property|
+      describe "#{property}" do
+        it { expect(described_class.attrtype(property)).to eq :property }
+      end
+    end
+
+    describe 'api_token_plain' do
+      it { expect(described_class.attrtype(:api_token_plain)).to eq :property }
+
+      it 'should support valid hexstrings' do
+        value = '51a8b1dd95bc76b1a2869356c043e8b9'
+        expect { described_class.new(
+          :name => 'nobody',
+          :api_token_plain => value
+        ) }.to_not raise_error
+      end
+
+      %w[ 51a8b1dd95bc76b1a2869356c043e8b
+          51a8b1dd95bc76b1a2869356c043e8b99 ].each do |value|
+        it 'should reject hexstrings of invalid length' do
+          expect { described_class.new(
+            :name => 'nobody',
+            :api_token_plain => value
+          ) }.to raise_error(Puppet::ResourceError, /is not a 32char hex string/)
+        end
+      end
+    end #api_token_plain
+
+    describe 'public_keys' do
+      it { expect(described_class.attrtype(:public_keys)).to eq :property }
+
+      it 'should support single string' do
+        value = 'ssh-rsa blah comment'
+        user = described_class.new(:name => 'nobody', :public_keys => value)
+        expect(user[:public_keys]).to eq [value]
+      end
+
+      it 'should support array of string' do
+        value = ['ssh-rsa blah comment', 'ssh-rsa foo comment']
+        user = described_class.new(:name => "nobody", :public_keys => value)
+        expect(user[:public_keys]).to eq value
+      end
+    end #public_keys
+  end #properties
+
+  describe 'autorequire' do
+    it_behaves_like 'autorequires cli resources'
+  end
+end

--- a/spec/unit/puppet_x/jenkins/config_spec.rb
+++ b/spec/unit/puppet_x/jenkins/config_spec.rb
@@ -1,0 +1,147 @@
+require 'spec_helper'
+
+require 'puppet_x/jenkins/config'
+
+describe PuppetX::Jenkins::Config do
+  DEFAULTS = {
+    :cli_jar         => '/usr/lib/jenkins/jenkins-cli.jar',
+    :port            => 8080,
+    :ssh_private_key => nil,
+    :puppet_helper   => '/usr/lib/jenkins/puppet_helper.groovy',
+    :cli_tries       => 30,
+    :cli_try_sleep   => 2,
+  }
+
+  shared_context 'facts' do
+    before do
+      Facter.add(:jenkins_cli_jar) { setcode { 'fact.jar' } }
+      Facter.add(:jenkins_port) { setcode { 11 } }
+      Facter.add(:jenkins_ssh_private_key) { setcode { 'fact.id_rsa' } }
+      Facter.add(:jenkins_puppet_helper) { setcode { 'fact.groovy' } }
+      Facter.add(:jenkins_cli_tries) { setcode { 22 } }
+      Facter.add(:jenkins_cli_try_sleep) { setcode { 33 } }
+    end
+  end
+
+  shared_examples 'returns default values' do |param|
+    it 'should return default values' do
+      DEFAULTS.each do |k, v|
+        expect(config[k]).to eq v
+      end
+    end
+  end # returns default values
+
+  shared_examples 'returns fact values' do |param|
+    it 'should return fact values' do
+      DEFAULTS.each do |k, v|
+        expect(config[k]).to eq Facter.value("jenkins_#{k.to_s}".to_sym)
+      end
+    end
+  end # returns fact values
+
+  shared_examples 'returns catalog values' do |param|
+    it 'should return catalog values' do
+      config = catalog.resource(:class, 'jenkins::cli::config')
+
+      DEFAULTS.each do |k, v|
+        expect(config[k]).to eq config[k]
+      end
+    end
+  end # returns catalog values
+
+  before(:each) { Facter.clear }
+
+  # we are relying on a side effect of this method being to test features /
+  # load libs
+  describe "#initialize" do
+    it { expect(described_class.new).to be_kind_of PuppetX::Jenkins::Config }
+  end
+
+  describe "#[]" do
+    context 'unknown config key' do
+      it do
+       expect{described_class.new[:foo]}
+        .to raise_error(PuppetX::Jenkins::Config::UnknownConfig)
+      end
+    end # unknown config key
+
+    context 'no catalog' do
+      let(:config) { described_class.new }
+
+      context 'no facts' do
+        include_examples 'returns default values'
+      end # no facts
+
+      context 'with facts' do
+        include_examples 'returns fact values' do
+          include_context 'facts'
+        end
+      end # with facts
+    end # no catalog
+
+    context 'with catalog' do
+      let(:catalog) { Puppet::Resource::Catalog.new }
+      let(:config) { described_class.new(catalog) }
+
+      context 'no jenkins::cli::config class' do
+        context 'no facts' do
+          include_examples 'returns default values'
+        end # no facts
+
+        context 'with facts' do
+          include_examples 'returns fact values' do
+            include_context 'facts'
+          end
+        end # with facts
+      end # no jenkins::cli::config class
+
+      context 'with jenkins::cli::config class' do
+        context 'with no params' do
+          before do
+            jenkins = Puppet::Type.type(:component).new(
+              :name => 'jenkins::cli::config',
+            )
+
+            catalog.add_resource jenkins
+          end
+
+          context 'no facts' do
+            include_examples 'returns default values'
+          end # no facts
+
+          context 'with facts' do
+            include_examples 'returns fact values' do
+              include_context 'facts'
+            end
+          end # with facts
+        end # with no params
+
+        context 'with all params' do
+          before do
+            jenkins = Puppet::Type.type(:component).new(
+              :name            => 'jenkins::cli::config',
+              :cli_jar         => 'cat.jar',
+              :port            => 111,
+              :ssh_private_key => 'cat.id_rsa',
+              :puppet_helper   => 'cat.groovy',
+              :cli_tries       => 222,
+              :cli_try_sleep   => 333,
+            )
+
+            catalog.add_resource jenkins
+          end
+
+          context 'no facts' do
+            include_examples 'returns catalog values'
+          end # no facts
+
+          context 'with facts' do
+            include_examples 'returns catalog values' do
+              include_context 'facts'
+            end
+          end # with facts
+        end # with all params
+      end # no jenkins::cli::config class
+    end # with catalog
+  end # #[]
+end

--- a/spec/unit/puppet_x/jenkins/provider/cli_spec.rb
+++ b/spec/unit/puppet_x/jenkins/provider/cli_spec.rb
@@ -1,0 +1,746 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_providers'
+
+# we need to make sure retries is always loaded or random test ordering can
+# cause failures when a side effect hasn't yet caused the lib to be loaded
+require 'retries'
+require 'puppet_x/jenkins/provider/cli'
+
+describe PuppetX::Jenkins::Provider::Cli do
+  AuthError = PuppetX::Jenkins::Provider::Cli::AuthError
+  UnknownError = PuppetX::Jenkins::Provider::Cli::UnknownError
+
+  CLI_AUTH_ERRORS =  [<<-EOS, <<-EOS, <<-EOS]
+    anonymous is missing the Overall/Read permission
+  EOS
+    You must authenticate to access this Jenkins.
+    Use --username/--password/--password-file parameters or login command.
+  EOS
+    anonymous is missing the Overall/RunScripts permission
+  EOS
+
+  shared_context 'facts' do
+    before do
+      Facter.add(:jenkins_cli_jar) { setcode { 'fact.jar' } }
+      Facter.add(:jenkins_port) { setcode { 11 } }
+      Facter.add(:jenkins_ssh_private_key) { setcode { 'fact.id_rsa' } }
+      Facter.add(:jenkins_puppet_helper) { setcode { 'fact.groovy' } }
+      Facter.add(:jenkins_cli_tries) { setcode { 22 } }
+      Facter.add(:jenkins_cli_try_sleep) { setcode { 33 } }
+    end
+  end
+
+  before(:each) { Facter.clear }
+
+  before(:each) do
+    # clear class level state
+    if described_class.class_variable_defined?(:@@cli_auth_required)
+       described_class.class_variable_set(:@@cli_auth_required, false)
+    end
+  end
+
+  before(:each) do
+    allow(described_class).to receive(:command).with(:java).and_return('java')
+  end
+
+  describe "::suitable?" do
+    it { expect(described_class.suitable?).to eq true }
+  end
+
+  include_examples 'confines to cli dependencies'
+
+  describe "::sname" do
+    it "should return a short class name" do
+      expect(described_class.sname).to eq "Jenkins::Provider::Cli"
+    end
+  end
+
+  describe "::instances" do
+    it "should not be implemented" do
+      expect{ described_class.instances }.to raise_error(Puppet::DevError)
+    end
+  end
+
+  describe "::prefetch" do
+    let(:catalog) { Puppet::Resource::Catalog.new }
+
+    it "should associate a provider with an instance" do
+      resource = Puppet::Type.type(:notify).new(:name => 'test')
+      catalog.add_resource resource
+
+      provider = described_class.new(:name => 'test')
+
+      expect(described_class).to receive(:instances).
+        with(catalog) { [provider] }
+
+      described_class.prefetch({resource.name => resource})
+
+      expect(resource.provider).to eq provider
+    end
+
+    it 'should not break an existing resource/provider association' do
+      resource = Puppet::Type.type(:notify).new(:name => 'test')
+      catalog.add_resource resource
+
+      provider = described_class.new(:name => 'test')
+      resource.provider = provider
+
+      expect(described_class).to receive(:instances).
+        with(catalog) { [provider] }
+
+      described_class.prefetch({resource.name => resource})
+
+      expect(resource.provider).to eq provider
+    end
+  end # ::prefetch
+
+  describe '#create' do
+    context ':ensure' do
+      it do
+        provider = described_class.new
+
+        expect(provider.instance_variable_get(:@property_hash)[:ensure]).to eq nil
+        provider.create
+        expect(provider.instance_variable_get(:@property_hash)[:ensure]).to eq :present
+      end
+    end
+  end # #create
+
+  describe '#exists?' do
+    context 'when :ensure is unset' do
+      it do
+        provider = described_class.new
+        expect(provider.exists?).to eq false
+      end
+    end
+
+    context 'when :ensure is :absent' do
+      it 'should return true' do
+        provider = described_class.new({ :ensure => :absent })
+        expect(provider.exists?).to eq false
+      end
+    end
+
+    context 'when :ensure is :present' do
+      it 'should return true' do
+        provider = described_class.new({ :ensure => :present })
+        expect(provider.exists?).to eq true
+      end
+    end
+  end # #exists?'
+
+  describe '#destroy' do
+    context ':ensure' do
+      it do
+        provider = described_class.new
+
+        expect(provider.instance_variable_get(:@property_hash)[:ensure]).to eq nil
+        provider.destroy
+        expect(provider.instance_variable_get(:@property_hash)[:ensure]).to eq :absent
+      end
+    end
+  end # #destroy
+
+  describe '#flush' do
+    it 'should clear @property_hash' do
+      provider = described_class.new
+      provider.create
+      provider.flush
+
+      expect(provider.instance_variable_get(:@property_hash)).to eq({})
+    end
+  end # #flush
+
+  describe '#cli' do
+    let(:provider) { described_class.new }
+
+    it 'should be an instance method' do
+      expect(provider).to respond_to(:cli)
+    end
+
+    it 'should have the same method signature as ::cli' do
+      expect(described_class.new).to respond_to(:cli).with(2).arguments
+    end
+
+    it 'should wrap ::cli class method' do
+      expect(described_class).to receive(:cli).with('foo', {})
+      provider.cli('foo', {})
+    end
+
+    it 'should extract the catalog from the resource' do
+      resource = Puppet::Type.type(:notify).new(:name => 'test')
+      catalog = Puppet::Resource::Catalog.new
+      resource.provider = provider
+      catalog.add_resource resource
+
+      expect(described_class).to receive(:cli).with(
+        'foo', { :catalog => catalog }
+      )
+
+      provider.cli('foo', {})
+    end
+  end # #cli
+
+  describe '#clihelper' do
+    let(:provider) { described_class.new }
+
+    it 'should be an instance method' do
+      expect(provider).to respond_to(:clihelper)
+    end
+
+    it 'should have the same method signature as ::clihelper' do
+      expect(described_class.new).to respond_to(:clihelper).with(2).arguments
+    end
+
+    it 'should wrap ::clihelper class method' do
+      expect(described_class).to receive(:clihelper).with('foo', {})
+      provider.clihelper('foo', {})
+    end
+
+    it 'should extract the catalog from the resource' do
+      resource = Puppet::Type.type(:notify).new(:name => 'test')
+      catalog = Puppet::Resource::Catalog.new
+      resource.provider = provider
+      catalog.add_resource resource
+
+      expect(described_class).to receive(:clihelper).with(
+        'foo', { :catalog => catalog }
+      )
+
+      provider.clihelper('foo', {})
+    end
+  end # #clihelper
+
+  describe '::clihelper' do
+    shared_examples 'uses default values' do
+      it 'should use default values' do
+        expect(described_class).to receive(:cli).with(
+          ['groovy', '/usr/lib/jenkins/puppet_helper.groovy', 'foo'], nil
+        )
+
+        described_class.clihelper('foo')
+      end
+    end # uses default values
+
+    shared_examples 'uses fact values' do
+      it 'should use fact values' do
+        expect(described_class).to receive(:cli).with(
+          ['groovy', 'fact.groovy', 'foo' ], nil
+        )
+
+        described_class.clihelper('foo')
+      end
+    end # uses fact values
+
+    shared_examples 'uses catalog values' do
+      it 'should use catalog values' do
+        expect(described_class).to receive(:cli).with(
+          ['groovy', 'cat.groovy', 'foo'],
+          { :catalog => catalog },
+        )
+
+        described_class.clihelper('foo', { :catalog => catalog })
+      end
+    end # uses catalog values
+
+    it 'should be a class method' do
+      expect(described_class).to respond_to(:clihelper)
+    end
+
+    it 'should wrap ::cli class method' do
+      expect(described_class).to receive(:cli)
+      described_class.clihelper('foo')
+    end
+
+    context 'no catalog' do
+      context 'no facts' do
+        include_examples 'uses default values'
+      end # no facts
+
+      context 'with facts' do
+        include_context 'facts'
+
+        include_examples 'uses fact values'
+      end # with facts
+    end # no catalog
+
+    context 'with catalog' do
+      let(:catalog) { Puppet::Resource::Catalog.new }
+
+      context 'no jenkins::cli::config class' do
+        context 'no facts' do
+          include_examples 'uses default values'
+        end # no facts
+
+        context 'with facts' do
+          include_context 'facts'
+
+          include_examples 'uses fact values'
+        end # with facts
+      end # no jenkins::cli::config class
+
+      context 'with jenkins::cli::config class' do
+        before do
+          jenkins = Puppet::Type.type(:component).new(
+            :name          => 'jenkins::cli::config',
+            :puppet_helper => 'cat.groovy',
+          )
+
+          catalog.add_resource jenkins
+        end
+
+        context 'no facts' do
+          include_examples 'uses catalog values'
+        end # no facts
+
+        context 'with facts' do
+          include_context 'facts'
+
+          include_examples 'uses catalog values'
+        end # with facts
+      end # with jenkins::cli::config class
+    end # with catalog
+  end # ::clihelper
+
+  describe '::cli' do
+    before(:each) do
+      # disable with_retries sleeping to [vastly] speed up testing
+      #
+      # we are relying the side effects of ::suitable? from a previous example
+      Retries.sleep_enabled = false
+    end
+
+    shared_examples 'uses default values' do
+      it 'should use default values' do
+        expect(described_class.superclass).to receive(:execute).with(
+          [
+            'java',
+            '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+            '-s', 'http://localhost:8080',
+            'foo'
+          ],
+          { :failonfail => true, :combine => true }
+        )
+
+        described_class.cli('foo')
+      end
+    end # uses default values
+
+    shared_examples 'uses fact values' do
+      it 'should use fact values' do
+        expect(described_class.superclass).to receive(:execute).with(
+          [
+            'java',
+            '-jar', 'fact.jar',
+            '-s', 'http://localhost:11',
+            'foo'
+          ],
+          { :failonfail => true, :combine => true }
+        )
+
+        described_class.cli('foo')
+      end
+    end # uses fact values
+
+    shared_examples 'uses catalog values' do
+      it 'should use catalog values' do
+        expect(described_class.superclass).to receive(:execute).with(
+          [
+            'java',
+            '-jar', 'cat.jar',
+            '-s', 'http://localhost:111',
+            'foo'
+          ],
+          { :failonfail => true, :combine => true}
+        )
+
+        described_class.cli('foo', { :catalog => catalog })
+      end
+    end # uses catalog values
+
+    it 'should be a class method' do
+      expect(described_class).to respond_to(:cli)
+    end
+
+    it 'should wrap the superclasses ::execute method' do
+      expect(described_class.superclass).to receive(:execute)
+      described_class.cli('foo')
+    end
+
+    context 'no catalog' do
+      context 'no facts' do
+        include_examples 'uses default values'
+      end # no facts
+
+      context 'with facts' do
+        include_context 'facts'
+
+        include_examples 'uses fact values'
+      end # with facts
+    end # no catalog
+
+    context 'with catalog' do
+      let(:catalog) { Puppet::Resource::Catalog.new }
+
+      context 'no jenkins::cli::config class' do
+        context 'no facts' do
+          include_examples 'uses default values'
+        end # no facts
+
+        context 'with facts' do
+          include_context 'facts'
+
+          include_examples 'uses fact values'
+        end # with facts
+      end # no jenkins::cli::config class
+
+      context 'with jenkins::cli::config class' do
+        before do
+          jenkins = Puppet::Type.type(:component).new(
+            :name            => 'jenkins::cli::config',
+            :cli_jar         => 'cat.jar',
+            :port            => 111,
+            :ssh_private_key => 'cat.id_rsa',
+            :cli_tries       => 222,
+            :cli_try_sleep   => 333,
+          )
+
+          catalog.add_resource jenkins
+        end
+
+        context 'no facts' do
+          include_examples 'uses catalog values'
+        end # no facts
+
+        context 'with facts' do
+          include_context 'facts'
+
+          include_examples 'uses catalog values'
+        end # with facts
+      end # with jenkins::cli::config class
+    end # with catalog
+
+    context 'auth failure' do
+      context 'without ssh_private_key' do
+        CLI_AUTH_ERRORS.each do |error|
+          it 'should not retry cli on AuthError exception' do
+            expect(described_class.superclass).to receive(:execute).with(
+              [
+                'java',
+                '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+                '-s', 'http://localhost:8080',
+                'foo'
+              ],
+              { :failonfail => true, :combine => true }
+            ).and_raise(AuthError, error)
+
+            expect { described_class.cli('foo') }.
+              to raise_error(AuthError)
+          end
+        end
+      end
+      # without ssh_private_key
+
+      context 'with ssh_private_key' do
+        let(:catalog) { Puppet::Resource::Catalog.new }
+        before(:each) do
+          jenkins = Puppet::Type.type(:component).new(
+            :name            => 'jenkins::cli::config',
+            :ssh_private_key => 'cat.id_rsa',
+          )
+          catalog.add_resource jenkins
+        end
+
+        it 'should try cli without auth first' do
+          expect(described_class.superclass).to receive(:execute).with(
+            [
+              'java',
+              '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+              '-s', 'http://localhost:8080',
+              'foo'
+            ],
+            { :failonfail => true, :combine => true }
+          )
+
+          described_class.cli('foo', { :catalog => catalog })
+        end
+
+        CLI_AUTH_ERRORS.each do |error|
+          it 'should retry cli on AuthError exception' do
+            expect(described_class.superclass).to receive(:execute).with(
+              [
+                'java',
+                '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+                '-s', 'http://localhost:8080',
+                'foo'
+              ],
+              { :failonfail => true, :combine => true }
+            ).and_raise(AuthError, error)
+
+            expect(described_class.superclass).to receive(:execute).with(
+              [
+                'java',
+                '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+                '-s', 'http://localhost:8080',
+                '-i', 'cat.id_rsa',
+                'foo'
+              ],
+              { :failonfail => true, :combine => true }
+            )
+
+            described_class.cli('foo', { :catalog => catalog })
+
+            # and it should remember that auth is required
+            expect(described_class.superclass).to_not receive(:execute).with(
+              [
+                'java',
+                '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+                '-s', 'http://localhost:8080',
+                'foo'
+              ],
+              { :failonfail => true, :combine => true }
+            )
+
+            expect(described_class.superclass).to receive(:execute).with(
+              [
+                'java',
+                '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+                '-s', 'http://localhost:8080',
+                '-i', 'cat.id_rsa',
+                'foo'
+              ],
+              { :failonfail => true, :combine => true }
+            )
+
+            described_class.cli('foo', { :catalog => catalog })
+          end
+        end
+      end # with ssh_private_key
+    end # auth failure
+
+    context 'when UnknownError exception' do
+      let(:catalog) { Puppet::Resource::Catalog.new }
+
+      context 'retry n times' do
+        it 'by default' do
+          jenkins = Puppet::Type.type(:component).new(
+            :name => 'jenkins::cli::config',
+          )
+          catalog.add_resource jenkins
+
+          expect(described_class.superclass).to receive(:execute).with(
+            [
+              'java',
+              '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+              '-s', 'http://localhost:8080',
+              'foo'
+            ],
+            { :failonfail => true, :combine => true }
+          ).exactly(30).times.and_raise(UnknownError, "foo")
+
+          expect { described_class.cli('foo', { :catalog => catalog }) }.
+            to raise_error(UnknownError, "foo")
+        end
+
+        it 'from catalog value' do
+          jenkins = Puppet::Type.type(:component).new(
+            :name      => 'jenkins::cli::config',
+            :cli_tries => 2,
+          )
+          catalog.add_resource jenkins
+
+          expect(described_class.superclass).to receive(:execute).with(
+            [
+              'java',
+              '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+              '-s', 'http://localhost:8080',
+              'foo'
+            ],
+            { :failonfail => true, :combine => true }
+          ).exactly(2).times.and_raise(UnknownError, "foo")
+
+          expect { described_class.cli('foo', { :catalog => catalog }) }.
+            to raise_error(UnknownError, "foo")
+        end
+
+        it 'from fact' do
+          Facter.add(:jenkins_cli_tries) { setcode { 3 } }
+
+          jenkins = Puppet::Type.type(:component).new(
+            :name => 'jenkins::cli::config',
+          )
+          catalog.add_resource jenkins
+
+          expect(described_class.superclass).to receive(:execute).with(
+            [
+              'java',
+              '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+              '-s', 'http://localhost:8080',
+              'foo'
+            ],
+            { :failonfail => true, :combine => true }
+          ).exactly(3).times.and_raise(UnknownError, "foo")
+
+          expect { described_class.cli('foo', { :catalog => catalog }) }.
+            to raise_error(UnknownError, "foo")
+        end
+
+        it 'from catalog overriding fact' do
+          Facter.add(:jenkins_cli_tries) { setcode { 3 } }
+
+          jenkins = Puppet::Type.type(:component).new(
+            :name      => 'jenkins::cli::config',
+            :cli_tries => 2,
+          )
+          catalog.add_resource jenkins
+
+          expect(described_class.superclass).to receive(:execute).with(
+            [
+              'java',
+              '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+              '-s', 'http://localhost:8080',
+              'foo'
+            ],
+            { :failonfail => true, :combine => true }
+          ).exactly(2).times.and_raise(UnknownError, "foo")
+
+          expect { described_class.cli('foo', { :catalog => catalog }) }.
+            to raise_error(UnknownError, "foo")
+        end
+      end # n times
+
+      context 'waiting up to n seconds' do
+        # this isn't behavioral testing because we don't want to either wait
+        # for the wallclock delay timeout or attempt to accurate time examples
+        it 'by default' do
+          jenkins = Puppet::Type.type(:component).new(
+            :name => 'jenkins::cli::config',
+          )
+          catalog.add_resource jenkins
+
+          expect(described_class).to receive(:with_retries).with(hash_including(:max_sleep_seconds => 2))
+
+          described_class.cli('foo', { :catalog => catalog })
+        end
+
+        it 'from catalog value' do
+          jenkins = Puppet::Type.type(:component).new(
+            :name          => 'jenkins::cli::config',
+            :cli_try_sleep => 3,
+          )
+          catalog.add_resource jenkins
+
+          expect(described_class).to receive(:with_retries).with(hash_including(:max_sleep_seconds => 3))
+
+          described_class.cli('foo', { :catalog => catalog })
+        end
+
+        it 'from fact' do
+          Facter.add(:jenkins_cli_try_sleep) { setcode { 4 } }
+
+          jenkins = Puppet::Type.type(:component).new(
+            :name => 'jenkins::cli::config',
+          )
+          catalog.add_resource jenkins
+
+          expect(described_class).to receive(:with_retries).with(hash_including(:max_sleep_seconds => 4))
+
+          described_class.cli('foo', { :catalog => catalog })
+        end
+
+        it 'from catalog overriding fact' do
+          Facter.add(:jenkins_cli_try_sleep) { setcode { 4 } }
+
+          jenkins = Puppet::Type.type(:component).new(
+            :name          => 'jenkins::cli::config',
+            :cli_try_sleep => 3,
+          )
+          catalog.add_resource jenkins
+
+          expect(described_class).to receive(:with_retries).with(hash_including(:max_sleep_seconds => 3))
+
+          described_class.cli('foo', { :catalog => catalog })
+        end
+      end
+    end # should retry cli on UnknownError
+
+    context 'options with :stdinjson' do
+      RSpec::Matchers.define :a_json_doc do |x|
+        match { |actual| JSON.parse(actual) == x }
+      end
+
+      let(:realm_oauth_json) do
+        <<-EOS
+          {
+              "setSecurityRealm": {
+                  "org.jenkinsci.plugins.GithubSecurityRealm": [
+                      "https://github.com",
+                      "https://api.github.com",
+                      "42",
+                      "43",
+                      "read:org"
+                  ]
+              }
+          }
+        EOS
+      end
+      let(:realm_oauth) { JSON.parse(realm_oauth_json) }
+
+      it 'should generate a temp file with json output' do
+        tmp = double('Template')
+
+        expect(Tempfile).to receive(:open) { tmp }
+        expect(tmp).to receive(:write).with(a_json_doc(realm_oauth))
+        expect(tmp).to receive(:flush)
+        expect(tmp).to receive(:close)
+        expect(tmp).to receive(:unlink)
+        expect(tmp).to receive(:path) { '/dne.tmp' }
+
+        expect(described_class.superclass).to receive(:execute).with(
+          [
+            'java',
+            '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+            '-s', 'http://localhost:8080',
+            'foo'
+          ],
+          {
+            :failonfail => true,
+            :combine    => true,
+            :stdinfile  => '/dne.tmp',
+          }
+        )
+
+        described_class.cli('foo', :stdinjson => realm_oauth)
+      end
+    end # options with :stdinjson
+
+    context 'options with :stdin' do
+      it 'should generate a temp file with stdin string' do
+        tmp = double('Template')
+
+        expect(Tempfile).to receive(:open) { tmp }
+        expect(tmp).to receive(:write).with('bar')
+        expect(tmp).to receive(:flush)
+        expect(tmp).to receive(:close)
+        expect(tmp).to receive(:unlink)
+        expect(tmp).to receive(:path) { '/dne.tmp' }
+
+        expect(described_class.superclass).to receive(:execute).with(
+          [
+            'java',
+            '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
+            '-s', 'http://localhost:8080',
+            'foo'
+          ],
+          {
+            :failonfail => true,
+            :combine    => true,
+            :stdinfile  => '/dne.tmp',
+          }
+        )
+
+        described_class.cli('foo', :stdin => 'bar')
+      end
+    end # options with :stdin
+  end # ::cli
+end

--- a/spec/unit/puppet_x/jenkins/type/cli_spec.rb
+++ b/spec/unit/puppet_x/jenkins/type/cli_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+require 'unit/puppet_x/spec_jenkins_types'
+
+require 'puppet_x/jenkins/type/cli'
+
+PuppetX::Jenkins::Type::Cli.newtype(:test) {
+  newparam(:foo) { isnamevar }
+}
+
+describe Puppet::Type.type(:test) do
+  describe 'autorequire' do
+    it_behaves_like 'autorequires cli resources'
+  end
+end

--- a/spec/unit/puppet_x/jenkins/util_spec.rb
+++ b/spec/unit/puppet_x/jenkins/util_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+require 'puppet_x/jenkins/util'
+
+describe PuppetX::Jenkins::Util do
+  let(:data) do
+    {
+      :a => :undef,
+      :b => [
+        nil,
+        1,
+        {
+          :c => nil,
+          :d => [
+            :undef,
+            1
+          ],
+          :e => 1,
+        }
+      ],
+      :f => 1,
+    }
+  end
+
+  describe "::unundef" do
+    it 'should convert :undef values to nil' do
+      expect(described_class.unundef(data)).to eq({
+        :a => nil,
+        :b => [
+          nil,
+          1,
+          {
+            :c => nil,
+            :d => [
+              nil,
+              1,
+            ],
+            :e => 1,
+          }
+        ],
+        :f => 1,
+      })
+    end
+  end # unundef
+
+  describe "::undefize" do
+    it 'should convert nil values to :undef' do
+      expect(described_class.undefize(data)).to eq({
+        :a => :undef,
+        :b => [
+          :undef,
+          1,
+          {
+            :c => :undef,
+            :d => [
+              :undef,
+              1
+            ],
+            :e => 1,
+          }
+        ],
+        :f => 1,
+      })
+    end
+  end # undefize
+
+  describe "::iterate" do
+
+    it 'should not transform without block' do
+      expect(described_class.iterate(data)).to eq(data)
+    end
+
+    it 'should not affect hash keys' do
+      expect(described_class.iterate(data) { 5 }).to eq({
+        :a => 5,
+        :b => [
+          5,
+          5,
+          {
+            :c => 5,
+            :d => [
+              5,
+              5,
+            ],
+            :e => 5,
+          }
+        ],
+        :f => 5,
+      })
+    end
+  end # iterate
+end

--- a/spec/unit/puppet_x/spec_jenkins_providers.rb
+++ b/spec/unit/puppet_x/spec_jenkins_providers.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+shared_examples 'confines to cli dependencies' do
+  describe "confine" do
+    it 'should have no matched confines' do
+      expect(described_class.confine_collection.summary).to eq({})
+    end
+
+    let(:confines) do
+      described_class.confine_collection.instance_variable_get(:@confines)
+    end
+
+    context 'feature :retries' do
+      it do
+        expect(confines).to include(
+          be_kind_of(Puppet::Confine::Feature).
+          and have_attributes(:values => [:retries])
+        )
+      end
+    end
+
+    context 'commands :java' do
+      it do
+        expect(confines).to include(
+          be_kind_of(Puppet::Confine::Exists).
+          and have_attributes(:values => ['java'])
+        )
+      end
+    end
+  end
+
+  describe "commands" do
+    before(:each) do
+      allow(described_class).to receive(:command).with(:java).and_return('java')
+    end
+
+    context 'java' do
+      it { expect(described_class.command(:java)).to eq('java') }
+      it { expect(described_class).to respond_to(:java) }
+    end
+  end
+end

--- a/spec/unit/puppet_x/spec_jenkins_types.rb
+++ b/spec/unit/puppet_x/spec_jenkins_types.rb
@@ -1,0 +1,374 @@
+require 'spec_helper'
+
+shared_examples 'generic namevar' do |name|
+  it { expect(described_class.attrtype(name)).to eq :param }
+
+  it "should be the namevar" do
+    expect(described_class.key_attributes).to eq [name]
+  end
+end # generic namevar
+
+shared_examples 'generic ensurable' do |*allowed|
+  allow ||= [:present, :absent]
+
+  context 'attrtype' do
+    it { expect(described_class.attrtype(:ensure)).to eq :property }
+  end
+
+  context 'class' do
+    it do
+      expect(described_class.propertybyname(:ensure).ancestors).
+        to include(Puppet::Property::Ensure)
+    end
+  end
+
+  it "should have no default value" do
+    user = described_class.new(:name => "nobody")
+    expect(user.should(:ensure)).to be_nil
+  end
+
+  allowed.each do |value|
+    it "should support #{value} as a value to :ensure" do
+      expect { described_class.new(:name => "nobody", :ensure => value) }.to_not raise_error
+    end
+  end
+
+  it "should reject unknown values" do
+    expect { described_class.new(:name => "nobody", :ensure => :foo) }.to raise_error(Puppet::Error)
+  end
+end # generic ensurable
+
+shared_examples 'validated property' do |param, default, allowed|
+  context 'attrtype' do
+    it { expect(described_class.attrtype(param)).to eq :property }
+  end
+
+  allowed.each do |value|
+    it "should support #{value} as a value" do
+      expect { described_class.new(:name => 'nobody', param => value) }.
+        to_not raise_error
+    end
+  end
+
+  if default.nil?
+    it "should have no default value" do
+      resource = described_class.new(:name => 'nobody')
+      expect(resource.should(param)).to be_nil
+    end
+  else
+    it "should default to #{default}" do
+      resource = described_class.new(:name => 'nobody')
+      expect(resource.should(param)).to eq default
+    end
+  end
+
+  it "should reject unknown values" do
+    expect { described_class.new(:name => 'nobody',
+                                 param => :foo) }.
+      to raise_error(Puppet::Error)
+  end
+end # validated property
+
+shared_examples 'boolean property' do |param, default|
+  it 'does not allow non-boolean values' do
+    expect {
+      described_class.new(:name => 'foo', param => 'unknown')
+    }.to raise_error Puppet::ResourceError, /expected a boolean value/
+  end
+
+  it_behaves_like 'validated property', param, default, [true, false]
+end # boolean property
+
+shared_examples 'array_matching property' do |param|
+  context 'attrtype' do
+    it { expect(described_class.attrtype(:arguments)).to eq :property }
+  end
+
+  context 'array_matching' do
+    it do
+      expect(described_class.attrclass(:arguments).array_matching).to eq :all
+    end
+  end
+
+  it "should support an array of mixed types" do
+    value = [true, "foo"]
+    resource = described_class.new(:name => "test", :arguments => value)
+    expect(resource[:arguments]).to eq value
+  end
+end # array_matching property
+
+shared_examples 'autorequires cli resources' do
+  before(:each) { Facter.clear }
+
+  it "should autorequire service" do
+    service_resource = Puppet::Type.type(:service).new(
+      :name => 'jenkins',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource service_resource
+    catalog.add_resource resource
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq service_resource
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire ssh_private_key file from catalog" do
+    ssh_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/id_rsa',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    jenkins = Puppet::Type.type(:component).new(
+      :name            => 'jenkins::cli::config',
+      :ssh_private_key => '/dne/id_rsa',
+    )
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource ssh_resource
+    catalog.add_resource resource
+    catalog.add_resource jenkins
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq ssh_resource
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire ssh_private_key file from fact" do
+    ssh_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/id_rsa',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    Facter.add(:jenkins_ssh_private_key) { setcode { '/dne/id_rsa' } }
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource ssh_resource
+    catalog.add_resource resource
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq ssh_resource
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire ssh_private_key file from catalog instead of fact" do
+    ssh_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/catalog',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    jenkins = Puppet::Type.type(:component).new(
+      :name            => 'jenkins::cli::config',
+      :ssh_private_key => '/dne/catalog',
+    )
+    Facter.add(:jenkins_ssh_private_key) { setcode { '/dne/fact' } }
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource ssh_resource
+    catalog.add_resource resource
+    catalog.add_resource jenkins
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq ssh_resource
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire puppet_helper file from catalog" do
+    helper_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/foo.groovy',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    jenkins = Puppet::Type.type(:component).new(
+      :name          => 'jenkins::cli::config',
+      :puppet_helper => '/dne/foo.groovy',
+    )
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource helper_resource
+    catalog.add_resource resource
+    catalog.add_resource jenkins
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq helper_resource
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire puppet_helper file from fact" do
+    helper_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/foo.groovy',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    Facter.add(:jenkins_puppet_helper) { setcode { '/dne/foo.groovy' } }
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource helper_resource
+    catalog.add_resource resource
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq helper_resource
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire puppet_helper file from catalog instead of fact" do
+    helper_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/catalog',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    jenkins = Puppet::Type.type(:component).new(
+      :name          => 'jenkins::cli::config',
+      :puppet_helper => '/dne/catalog',
+    )
+    Facter.add(:jenkins_puppet_helper) { setcode { '/dne/fact' } }
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource helper_resource
+    catalog.add_resource resource
+    catalog.add_resource jenkins
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq helper_resource
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire both ssh_private_key key and puppet_helper from catalog" do
+    ssh_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/id_rsa',
+    )
+    helper_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/foo.groovy',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    jenkins = Puppet::Type.type(:component).new(
+      :name            => 'jenkins::cli::config',
+      :ssh_private_key => '/dne/id_rsa',
+      :puppet_helper   => '/dne/foo.groovy',
+    )
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource ssh_resource
+    catalog.add_resource helper_resource
+    catalog.add_resource resource
+    catalog.add_resource jenkins
+    req = resource.autorequire
+
+    expect(req.size).to eq 2
+    expect(req[0].source).to eq ssh_resource
+    expect(req[0].target).to eq resource
+
+    expect(req[1].source).to eq helper_resource
+    expect(req[1].target).to eq resource
+  end
+end # when autorequiring resources
+
+shared_examples 'autorequires all jenkins_user resources' do
+  it "should autorequire single jenkins_user" do
+    larry = Puppet::Type.type(:jenkins_user).new(
+      :name => 'larry',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource larry
+    catalog.add_resource resource
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq larry
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire multiple jenkins_user(s)" do
+    larry = Puppet::Type.type(:jenkins_user).new(
+      :name => 'larry',
+    )
+    moe = Puppet::Type.type(:jenkins_user).new(
+      :name => 'moe',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource larry
+    catalog.add_resource moe
+    catalog.add_resource resource
+    req = resource.autorequire
+
+    expect(req.size).to eq 2
+    expect(req[0].source).to eq larry
+    expect(req[0].target).to eq resource
+
+    expect(req[1].source).to eq moe
+    expect(req[1].target).to eq resource
+  end
+end # autorequires all jenkins_user resources
+
+shared_examples 'autorequires jenkins_security_realm resource' do
+  it "should autorequire jenkins_security_realm resource" do
+    required = Puppet::Type.type(:jenkins_security_realm).new(
+      :name => 'test',
+    )
+    resource = described_class.new(
+      :name   => 'test',
+    )
+    if described_class.validproperty?(:ensure)
+      resource[:ensure] = :present
+    end
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource required
+    catalog.add_resource resource
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq required
+    expect(req[0].target).to eq resource
+  end
+end # autorequires jenkins_security_realm resource
+
+shared_examples 'autorequires jenkins_authorization_strategy resource' do
+  it "should autorequire jenkins_authorization_strategy resource" do
+    required = Puppet::Type.type(:jenkins_authorization_strategy).new(
+      :name => 'test',
+    )
+    resource = described_class.new(
+      :name   => 'test',
+    )
+    if described_class.validproperty?(:ensure)
+      resource[:ensure] = :present
+    end
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource required
+    catalog.add_resource resource
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq required
+    expect(req[0].target).to eq resource
+  end
+end # autorequires jenkins_authorization_strategy resource


### PR DESCRIPTION
This is a family of native types and providers with the aim of replacing direct usage of the `cli` jar via `exec` resources (E.g. `jenkins::cli:exec`).  The principle motivation is to resolve the "chicken vs egg" problem that occurs between the `cli` jar and jenkins when enabling security.  Similarly, it provides a mechanism to set the API token on a user account that can be used for the connection of swarm clients, which otherwise are unable to connect when using a security realm that does not use password (E.g. github-oauth).  It should be relatively easy to extend these types to provide additional functionality, such as supporting additional credentials types.

No attempt has been made to integrate the new types into the existing classes and defined types.  It should be possible to try them out in an essentially stand alone fashion against a running jenkins instance.  Preliminary and extremely terse notes are in [NATIVE_TYPES_AND_PROVIDERS.md](https://github.com/jhoblitt/puppet-jenkins/blob/feature/types_and_providers/NATIVE_TYPES_AND_PROVIDERS.md).

Comments, feedback, and/or bug reports would be greatly welcomed.