### PR TITLE
WIP: completely rework the way imports work for the native types

### DIFF
--- a/lib/puppet/provider/jenkins_authorization_strategy/cli.rb
+++ b/lib/puppet/provider/jenkins_authorization_strategy/cli.rb
@@ -1,5 +1,13 @@
-require 'puppet_x/jenkins/util'
-require 'puppet_x/jenkins/provider/cli'
+begin
+  require 'puppet_x/jenkins/util'
+  require 'puppet_x/jenkins/provider/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/util'
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/provider/cli'
+end
 
 Puppet::Type.type(:jenkins_authorization_strategy).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
 

--- a/lib/puppet/provider/jenkins_credentials/cli.rb
+++ b/lib/puppet/provider/jenkins_credentials/cli.rb
@@ -1,7 +1,15 @@
 require 'puppet/util/warnings'
 
-require 'puppet_x/jenkins/util'
-require 'puppet_x/jenkins/provider/cli'
+begin
+  require 'puppet_x/jenkins/util'
+  require 'puppet_x/jenkins/provider/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/util'
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/provider/cli'
+end
 
 Puppet::Type.type(:jenkins_credentials).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
 

--- a/lib/puppet/provider/jenkins_job/cli.rb
+++ b/lib/puppet/provider/jenkins_job/cli.rb
@@ -1,7 +1,15 @@
 require 'puppet/util/warnings'
 
-require 'puppet_x/jenkins/util'
-require 'puppet_x/jenkins/provider/cli'
+begin
+  require 'puppet_x/jenkins/util'
+  require 'puppet_x/jenkins/provider/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/util'
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/provider/cli'
+end
 
 Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
 

--- a/lib/puppet/provider/jenkins_num_executors/cli.rb
+++ b/lib/puppet/provider/jenkins_num_executors/cli.rb
@@ -1,5 +1,13 @@
-require 'puppet_x/jenkins/util'
-require 'puppet_x/jenkins/provider/cli'
+begin
+  require 'puppet_x/jenkins/util'
+  require 'puppet_x/jenkins/provider/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/util'
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/provider/cli'
+end
 
 Puppet::Type.type(:jenkins_num_executors).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
 

--- a/lib/puppet/provider/jenkins_security_realm/cli.rb
+++ b/lib/puppet/provider/jenkins_security_realm/cli.rb
@@ -1,5 +1,13 @@
-require 'puppet_x/jenkins/util'
-require 'puppet_x/jenkins/provider/cli'
+begin
+	require 'puppet_x/jenkins/util'
+  require 'puppet_x/jenkins/provider/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/util'
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/provider/cli'
+end
 
 Puppet::Type.type(:jenkins_security_realm).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
 

--- a/lib/puppet/provider/jenkins_slaveagent_port/cli.rb
+++ b/lib/puppet/provider/jenkins_slaveagent_port/cli.rb
@@ -1,5 +1,13 @@
-require 'puppet_x/jenkins/util'
-require 'puppet_x/jenkins/provider/cli'
+begin
+  require 'puppet_x/jenkins/util'
+  require 'puppet_x/jenkins/provider/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/util'
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/provider/cli'
+end
 
 Puppet::Type.type(:jenkins_slaveagent_port).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
 

--- a/lib/puppet/provider/jenkins_user/cli.rb
+++ b/lib/puppet/provider/jenkins_user/cli.rb
@@ -1,5 +1,13 @@
-require 'puppet_x/jenkins/util'
-require 'puppet_x/jenkins/provider/cli'
+begin
+  require 'puppet_x/jenkins/util'
+  require 'puppet_x/jenkins/provider/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/util'
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/provider/cli'
+end
 
 Puppet::Type.type(:jenkins_user).provide(:cli, :parent => PuppetX::Jenkins::Provider::Cli) do
 

--- a/lib/puppet/type/jenkins_authorization_strategy.rb
+++ b/lib/puppet/type/jenkins_authorization_strategy.rb
@@ -1,4 +1,11 @@
-require 'puppet_x/jenkins/type/cli'
+begin
+  require 'puppet_x/jenkins/type/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/type/cli'
+end
 
 PuppetX::Jenkins::Type::Cli.newtype(:jenkins_authorization_strategy) do
   @doc = "Manage Jenkins' authorization strategy"

--- a/lib/puppet/type/jenkins_credentials.rb
+++ b/lib/puppet/type/jenkins_credentials.rb
@@ -1,4 +1,11 @@
-require 'puppet_x/jenkins/type/cli'
+begin
+  require 'puppet_x/jenkins/type/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/type/cli'
+end
 
 PuppetX::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
   @doc = <<-EOS

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -1,6 +1,13 @@
 require 'puppet/property/boolean'
 
-require 'puppet_x/jenkins/type/cli'
+begin
+  require 'puppet_x/jenkins/type/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/type/cli'
+end
 
 PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
   @doc = "Manage Jenkins' jobs"

--- a/lib/puppet/type/jenkins_num_executors.rb
+++ b/lib/puppet/type/jenkins_num_executors.rb
@@ -1,4 +1,11 @@
-require 'puppet_x/jenkins/type/cli'
+begin
+  require 'puppet_x/jenkins/type/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/type/cli'
+end
 
 PuppetX::Jenkins::Type::Cli.newtype(:jenkins_num_executors) do
   @doc = "Manage Jenkins' number of executor slots"

--- a/lib/puppet/type/jenkins_security_realm.rb
+++ b/lib/puppet/type/jenkins_security_realm.rb
@@ -1,4 +1,11 @@
-require 'puppet_x/jenkins/type/cli'
+begin
+  require 'puppet_x/jenkins/type/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/type/cli'
+end
 
 PuppetX::Jenkins::Type::Cli.newtype(:jenkins_security_realm) do
   @doc = "Manage Jenkins' security realm"

--- a/lib/puppet/type/jenkins_slaveagent_port.rb
+++ b/lib/puppet/type/jenkins_slaveagent_port.rb
@@ -1,4 +1,11 @@
-require 'puppet_x/jenkins/type/cli'
+begin
+  require 'puppet_x/jenkins/type/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/type/cli'
+end
 
 PuppetX::Jenkins::Type::Cli.newtype(:jenkins_slaveagent_port) do
   @doc = "Manage Jenkins' slave agent listening port"

--- a/lib/puppet/type/jenkins_user.rb
+++ b/lib/puppet/type/jenkins_user.rb
@@ -1,4 +1,11 @@
-require 'puppet_x/jenkins/type/cli'
+begin
+  require 'puppet_x/jenkins/type/cli'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/type/cli'
+end
 
 PuppetX::Jenkins::Type::Cli.newtype(:jenkins_user) do
   @doc = "Manage Jenkins' user account information"

--- a/lib/puppet_x/jenkins.rb
+++ b/lib/puppet_x/jenkins.rb
@@ -1,2 +1,0 @@
-module PuppetX; end
-module PuppetX::Jenkins; end

--- a/lib/puppet_x/jenkins/config.rb
+++ b/lib/puppet_x/jenkins/config.rb
@@ -1,66 +1,69 @@
 require 'facter'
 
-require 'puppet_x/jenkins'
 require 'puppet/util/warnings'
 
 # This class is used to lookup common configuration values by first looking for
 # the desired key as parameter to the config class in the catalog, then
 # checking for a prefixed fact, and falling back to hard coded defaults.
-class PuppetX::Jenkins::Config
-  class UnknownConfig < ArgumentError; end
+module PuppetX
+  module Jenkins
+    class Config
+      class UnknownConfig < ArgumentError; end
 
-  DEFAULTS = {
-    :cli_jar         => '/usr/lib/jenkins/jenkins-cli.jar',
-    :port            => 8080,
-    :ssh_private_key => nil,
-    :puppet_helper   => '/usr/lib/jenkins/puppet_helper.groovy',
-    :cli_tries       => 30,
-    :cli_try_sleep   => 2,
-  }
-  CONFIG_CLASS = 'jenkins::cli::config'
-  FACT_PREFIX = 'jenkins_'
+      DEFAULTS = {
+        :cli_jar         => '/usr/lib/jenkins/jenkins-cli.jar',
+        :port            => 8080,
+        :ssh_private_key => nil,
+        :puppet_helper   => '/usr/lib/jenkins/puppet_helper.groovy',
+        :cli_tries       => 30,
+        :cli_try_sleep   => 2,
+      }
+      CONFIG_CLASS = 'jenkins::cli::config'
+      FACT_PREFIX = 'jenkins_'
 
-  def initialize(catalog = nil)
-    @catalog = catalog
-  end
+      def initialize(catalog = nil)
+        @catalog = catalog
+      end
 
-  def [](key)
-    key = key.to_sym
-    raise UnknownConfig unless DEFAULTS.has_key?(key)
+      def [](key)
+        key = key.to_sym
+        raise UnknownConfig unless DEFAULTS.has_key?(key)
 
-    value = catalog_lookup(key) || fact_lookup(key) || default_lookup(key)
-    return if value.nil?
+        value = catalog_lookup(key) || fact_lookup(key) || default_lookup(key)
+        return if value.nil?
 
-    Puppet::Util::Warnings.debug_once "config: #{key} = #{value}"
+        Puppet::Util::Warnings.debug_once "config: #{key} = #{value}"
 
-    # handle puppet 3.x passing in all values as strings and convert back to
-    # Integer/Fixnum
-    if Puppet.version =~ /^3/
-      default_type_integer?(key) ? value.to_i : value
-    else
-      value
+        # handle puppet 3.x passing in all values as strings and convert back to
+        # Integer/Fixnum
+        if Puppet.version =~ /^3/
+          default_type_integer?(key) ? value.to_i : value
+        else
+          value
+        end
+      end
+
+      def catalog_lookup(key)
+        return nil if @catalog.nil?
+
+        config = @catalog.resource(:class, CONFIG_CLASS)
+        return nil if config.nil?
+
+        config[key.to_sym]
+      end
+
+      def fact_lookup(key)
+        fact = FACT_PREFIX + key.to_s
+        Facter.value(fact.to_sym)
+      end
+
+      def default_lookup(key)
+        DEFAULTS[key]
+      end
+
+      def default_type_integer?(key)
+        DEFAULTS[key].is_a?(Integer)
+      end
     end
-  end
-
-  def catalog_lookup(key)
-    return nil if @catalog.nil?
-
-    config = @catalog.resource(:class, CONFIG_CLASS)
-    return nil if config.nil?
-
-    config[key.to_sym]
-  end
-
-  def fact_lookup(key)
-    fact = FACT_PREFIX + key.to_s
-    Facter.value(fact.to_sym)
-  end
-
-  def default_lookup(key)
-    DEFAULTS[key]
-  end
-
-  def default_type_integer?(key)
-    DEFAULTS[key].is_a?(Integer)
   end
 end

--- a/lib/puppet_x/jenkins/provider.rb
+++ b/lib/puppet_x/jenkins/provider.rb
@@ -1,3 +1,0 @@
-require 'puppet_x/jenkins'
-
-module PuppetX::Jenkins::Provider; end

--- a/lib/puppet_x/jenkins/provider/cli.rb
+++ b/lib/puppet_x/jenkins/provider/cli.rb
@@ -1,239 +1,251 @@
 require 'puppet/provider'
 require 'facter'
 
-require 'puppet_x/jenkins/config'
-require 'puppet_x/jenkins/provider'
+begin
+  require 'puppet_x/jenkins/config'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/config'
+end
 
-class PuppetX::Jenkins::Provider::Cli < Puppet::Provider
-  # stdout/stderr indicates an authentication failure
-  class AuthError < Puppet::ExecutionFailure; end
-  # any other execution error
-  class UnknownError < Puppet::ExecutionFailure; end
+module PuppetX
+  module Jenkins
+    module Provider
+      class Cli < Puppet::Provider
+        # stdout/stderr indicates an authentication failure
+        class AuthError < Puppet::ExecutionFailure; end
+        # any other execution error
+        class UnknownError < Puppet::ExecutionFailure; end
 
-  # push a shallow copy of the class confines into the subclass
-  # this includes the confine(s) needed for commands
-  #
-  # The subclass seems to function with an empty @commands and any value we try
-  # to push in will get reselt by ::initvars.
-  def self.inherited(subclass)
-    subclass.instance_variable_set(:@confine_collection, @confine_collection.dup)
-  end
-
-  # we must invoke ::initvars to setup variables needed by ::commands
-  self.initvars
-
-  commands :java => 'java'
-  confine :feature => :retries
-
-  # subclasses should inherit this value once it has been determined that
-  # jenkins requires authorization, it shortens the run time be elemating the
-  # need for each subclass to retest for an authenication failure.
-  #
-  # XXX this needs some consideration for how to handle the transistion from
-  # security being enabled to disabled
-  class_variable_set(:@@cli_auth_required, false)
-
-  # shorter class name
-  def self.sname
-    self.to_s[/.+::(Jenkins.+)/, 1]
-  end
-
-  def self.prefetch(resources)
-    Puppet.debug("#{sname} prefetch: #{resources.each_key.collect.to_a}")
-
-    catalog = resources.first[1].catalog
-
-    instances(catalog).each do |prov|
-      if resource = resources[prov.name]
-        resource.provider = prov
-      end
-    end
-  end
-
-  def create
-    @property_hash[:ensure] = :present
-  end
-
-  def exists?
-    @property_hash[:ensure] == :present
-  end
-
-  def destroy
-    @property_hash[:ensure] = :absent
-  end
-
-  def flush
-    @property_hash.clear
-  end
-
-  # if the provider instance has a resource (which it should outside of
-  # testing), add :catalog to the options hash so the caller doesn't have to
-  def clihelper(command, options = nil)
-    if resource and resource.catalog
-      options ||= {}
-      options[:catalog] ||= resource.catalog
-    end
-
-    args = []
-    args << command
-    args << options unless options.nil?
-    self.class.clihelper(*args)
-  end
-
-  def cli(command, options = nil)
-    if resource and resource.catalog
-      options ||= {}
-      options[:catalog] ||= resource.catalog
-    end
-
-    args = []
-    args << command
-    args << options unless options.nil?
-    self.class.cli(*args)
-  end
-
-  def self.clihelper(command, options = nil)
-    catalog = options.nil? ? nil : options[:catalog]
-    config = PuppetX::Jenkins::Config.new(catalog)
-
-    puppet_helper = config[:puppet_helper]
-
-    cli_cmd = ['groovy', puppet_helper] + [command]
-    cli_cmd.flatten!
-
-    cli(cli_cmd, options)
-  end
-
-  def self.cli(command, options = {})
-    if options.nil? || !options.key?(:stdinjson) && !options.key?(:stdin)
-      return execute_with_retry(command, options)
-    end
-
-    if options.key?(:stdinjson)
-      data = options.delete(:stdinjson)
-      input = JSON.pretty_generate(data)
-    end
-
-    if options.key?(:stdin)
-      input = options.delete(:stdin)
-    end
-
-    Puppet.debug("#{sname} stdin:\n#{input}")
-
-    # a tempfile block arg is not used to simplify mock testing :/
-    tmp = Tempfile.open(sname)
-    tmp.write input
-    tmp.flush
-    options[:stdinfile] = tmp.path
-    result = execute_with_retry(command, options)
-    tmp.close
-    tmp.unlink
-
-    result
-  end
-
-  def self.execute_with_retry(command, options = {})
-    options ||= {}
-    catalog = options.delete(:catalog)
-
-    options.merge!({ :failonfail => true })
-    # without combine, an execution exception message will not include the
-    # stderr
-    options.merge!({ :combine => true })
-
-    config = PuppetX::Jenkins::Config.new(catalog)
-    cli_jar         = config[:cli_jar]
-    port            = config[:port]
-    ssh_private_key = config[:ssh_private_key]
-    cli_tries       = config[:cli_tries]
-    cli_try_sleep   = config[:cli_try_sleep]
-
-    base_cmd = [
-      command(:java),
-      '-jar', cli_jar,
-      '-s', "http://localhost:#{port}",
-    ]
-
-    cli_cmd = base_cmd + [command]
-    cli_cmd.flatten!
-
-    auth_cmd = nil
-    unless ssh_private_key.nil?
-      auth_cmd = base_cmd + ['-i', ssh_private_key] + [command]
-      auth_cmd.flatten!
-    end
-
-    # retry on "unknown" execution errors but don't catch AuthErrors.  If an
-    # AuthError has bubbled up to this level it means either an ssh_private_key
-    # is required and we don't have one or that one we have was rejected.
-    handler = Proc.new do |exception, attempt_number, total_delay|
-      Puppet.debug("#{sname} caught #{exception.class.to_s.match(/::([^:]+)$/)[1]}; retry attempt #{attempt_number}; #{total_delay.round(3)} seconds have passed")
-    end
-    with_retries(
-      :max_tries          => cli_tries,
-      :base_sleep_seconds => 1,
-      :max_sleep_seconds  => cli_try_sleep,
-      :rescue             => UnknownError,
-      :handler            => handler,
-    ) do
-      result = execute_with_auth(cli_cmd, auth_cmd, options)
-      unless result == ''
-        Puppet.debug("#{sname} command stdout:\n#{result}")
-      end
-      return result
-    end
-  end
-  private_class_method :execute_with_retry
-
-  def self.execute_with_auth(cli_cmd, auth_cmd, options = {})
-    # auth will fail if if it is attempted with an ssh_private_key that
-    # hasn't yet been configured for a user.
-    Puppet.debug("#{sname} cli_auth_required: #{class_variable_get(:@@cli_auth_required)}")
-
-    # if no ssh_private_key is defined, the only option is to invoke the cli
-    # without auth
-    if auth_cmd.nil?
-      return execute_exceptionify(cli_cmd, options)
-    end
-
-    # we already know that auth is required
-    if class_variable_get(:@@cli_auth_required)
-      return execute_exceptionify(auth_cmd, options)
-    end
-
-    begin
-      # try first with no auth
-      return execute_exceptionify(cli_cmd, options)
-    rescue AuthError
-      # retry with auth
-      Puppet.debug("#{sname} cli auth failure -- retrying with ssh_private_key")
-      result = execute_exceptionify(auth_cmd, options)
-      class_variable_set(:@@cli_auth_required, true)
-      Puppet.debug("#{sname} cli_auth_required: #{class_variable_get(:@@cli_auth_required)}")
-      return result
-    end
-  end
-  private_class_method :execute_with_auth
-
-  # convert Puppet::ExecutionFailure into a ::AuthError exception if it appears
-  # that the command failure was due to an authication problem
-  def self.execute_exceptionify(*args)
-    cli_auth_errors = ['You must authenticate to access this Jenkins.',
-                       'anonymous is missing the Overall/Read permission',
-                       'anonymous is missing the Overall/RunScripts permission',
-                      ]
-    begin
-      #return Puppet::Provider.execute(*args)
-      return superclass.execute(*args)
-    rescue Puppet::ExecutionFailure => e
-      cli_auth_errors.each do |error|
-        if e.message.match(error)
-          raise AuthError, e.message, e.backtrace
+        # push a shallow copy of the class confines into the subclass
+        # this includes the confine(s) needed for commands
+        #
+        # The subclass seems to function with an empty @commands and any value we try
+        # to push in will get reselt by ::initvars.
+        def self.inherited(subclass)
+          subclass.instance_variable_set(:@confine_collection, @confine_collection.dup)
         end
-      end
 
-      raise UnknownError, e.message, e.backtrace
+        # we must invoke ::initvars to setup variables needed by ::commands
+        self.initvars
+
+        commands :java => 'java'
+        confine :feature => :retries
+
+        # subclasses should inherit this value once it has been determined that
+        # jenkins requires authorization, it shortens the run time be elemating the
+        # need for each subclass to retest for an authenication failure.
+        #
+        # XXX this needs some consideration for how to handle the transistion from
+        # security being enabled to disabled
+        class_variable_set(:@@cli_auth_required, false)
+
+        # shorter class name
+        def self.sname
+          self.to_s[/.+::(Jenkins.+)/, 1]
+        end
+
+        def self.prefetch(resources)
+          Puppet.debug("#{sname} prefetch: #{resources.each_key.collect.to_a}")
+
+          catalog = resources.first[1].catalog
+
+          instances(catalog).each do |prov|
+            if resource = resources[prov.name]
+              resource.provider = prov
+            end
+          end
+        end
+
+        def create
+          @property_hash[:ensure] = :present
+        end
+
+        def exists?
+          @property_hash[:ensure] == :present
+        end
+
+        def destroy
+          @property_hash[:ensure] = :absent
+        end
+
+        def flush
+          @property_hash.clear
+        end
+
+        # if the provider instance has a resource (which it should outside of
+        # testing), add :catalog to the options hash so the caller doesn't have to
+        def clihelper(command, options = nil)
+          if resource and resource.catalog
+            options ||= {}
+            options[:catalog] ||= resource.catalog
+          end
+
+          args = []
+          args << command
+          args << options unless options.nil?
+          self.class.clihelper(*args)
+        end
+
+        def cli(command, options = nil)
+          if resource and resource.catalog
+            options ||= {}
+            options[:catalog] ||= resource.catalog
+          end
+
+          args = []
+          args << command
+          args << options unless options.nil?
+          self.class.cli(*args)
+        end
+
+        def self.clihelper(command, options = nil)
+          catalog = options.nil? ? nil : options[:catalog]
+          config = PuppetX::Jenkins::Config.new(catalog)
+
+          puppet_helper = config[:puppet_helper]
+
+          cli_cmd = ['groovy', puppet_helper] + [command]
+          cli_cmd.flatten!
+
+          cli(cli_cmd, options)
+        end
+
+        def self.cli(command, options = {})
+          if options.nil? || !options.key?(:stdinjson) && !options.key?(:stdin)
+            return execute_with_retry(command, options)
+          end
+
+          if options.key?(:stdinjson)
+            data = options.delete(:stdinjson)
+            input = JSON.pretty_generate(data)
+          end
+
+          if options.key?(:stdin)
+            input = options.delete(:stdin)
+          end
+
+          Puppet.debug("#{sname} stdin:\n#{input}")
+
+          # a tempfile block arg is not used to simplify mock testing :/
+          tmp = Tempfile.open(sname)
+          tmp.write input
+          tmp.flush
+          options[:stdinfile] = tmp.path
+          result = execute_with_retry(command, options)
+          tmp.close
+          tmp.unlink
+
+          result
+        end
+
+        def self.execute_with_retry(command, options = {})
+          options ||= {}
+          catalog = options.delete(:catalog)
+
+          options.merge!({ :failonfail => true })
+          # without combine, an execution exception message will not include the
+          # stderr
+          options.merge!({ :combine => true })
+
+          config = PuppetX::Jenkins::Config.new(catalog)
+          cli_jar         = config[:cli_jar]
+          port            = config[:port]
+          ssh_private_key = config[:ssh_private_key]
+          cli_tries       = config[:cli_tries]
+          cli_try_sleep   = config[:cli_try_sleep]
+
+          base_cmd = [
+            command(:java),
+            '-jar', cli_jar,
+            '-s', "http://localhost:#{port}",
+          ]
+
+          cli_cmd = base_cmd + [command]
+          cli_cmd.flatten!
+
+          auth_cmd = nil
+          unless ssh_private_key.nil?
+            auth_cmd = base_cmd + ['-i', ssh_private_key] + [command]
+            auth_cmd.flatten!
+          end
+
+          # retry on "unknown" execution errors but don't catch AuthErrors.  If an
+          # AuthError has bubbled up to this level it means either an ssh_private_key
+          # is required and we don't have one or that one we have was rejected.
+          handler = Proc.new do |exception, attempt_number, total_delay|
+            Puppet.debug("#{sname} caught #{exception.class.to_s.match(/::([^:]+)$/)[1]}; retry attempt #{attempt_number}; #{total_delay.round(3)} seconds have passed")
+          end
+          with_retries(
+            :max_tries          => cli_tries,
+            :base_sleep_seconds => 1,
+            :max_sleep_seconds  => cli_try_sleep,
+            :rescue             => UnknownError,
+            :handler            => handler,
+          ) do
+            result = execute_with_auth(cli_cmd, auth_cmd, options)
+            unless result == ''
+              Puppet.debug("#{sname} command stdout:\n#{result}")
+            end
+            return result
+          end
+        end
+        private_class_method :execute_with_retry
+
+        def self.execute_with_auth(cli_cmd, auth_cmd, options = {})
+          # auth will fail if if it is attempted with an ssh_private_key that
+          # hasn't yet been configured for a user.
+          Puppet.debug("#{sname} cli_auth_required: #{class_variable_get(:@@cli_auth_required)}")
+
+          # if no ssh_private_key is defined, the only option is to invoke the cli
+          # without auth
+          if auth_cmd.nil?
+            return execute_exceptionify(cli_cmd, options)
+          end
+
+          # we already know that auth is required
+          if class_variable_get(:@@cli_auth_required)
+            return execute_exceptionify(auth_cmd, options)
+          end
+
+          begin
+            # try first with no auth
+            return execute_exceptionify(cli_cmd, options)
+          rescue AuthError
+            # retry with auth
+            Puppet.debug("#{sname} cli auth failure -- retrying with ssh_private_key")
+            result = execute_exceptionify(auth_cmd, options)
+            class_variable_set(:@@cli_auth_required, true)
+            Puppet.debug("#{sname} cli_auth_required: #{class_variable_get(:@@cli_auth_required)}")
+            return result
+          end
+        end
+        private_class_method :execute_with_auth
+
+        # convert Puppet::ExecutionFailure into a ::AuthError exception if it appears
+        # that the command failure was due to an authication problem
+        def self.execute_exceptionify(*args)
+          cli_auth_errors = ['You must authenticate to access this Jenkins.',
+                             'anonymous is missing the Overall/Read permission',
+                             'anonymous is missing the Overall/RunScripts permission',
+                            ]
+          begin
+            #return Puppet::Provider.execute(*args)
+            return superclass.execute(*args)
+          rescue Puppet::ExecutionFailure => e
+            cli_auth_errors.each do |error|
+              if e.message.match(error)
+                raise AuthError, e.message, e.backtrace
+              end
+            end
+
+            raise UnknownError, e.message, e.backtrace
+          end
+        end
+        private_class_method :execute_exceptionify
+      end
     end
   end
-  private_class_method :execute_exceptionify
 end

--- a/lib/puppet_x/jenkins/type.rb
+++ b/lib/puppet_x/jenkins/type.rb
@@ -1,3 +1,0 @@
-require 'puppet_x/jenkins'
-
-module PuppetX::Jenkins::Type; end

--- a/lib/puppet_x/jenkins/type/cli.rb
+++ b/lib/puppet_x/jenkins/type/cli.rb
@@ -1,28 +1,40 @@
-require 'puppet_x/jenkins/type'
-require 'puppet_x/jenkins/config'
+begin
+  require 'puppet_x/jenkins/config'
+rescue LoadError
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  jenkins = Puppet::Module.find('jenkins', Puppet[:environment].to_s)
+  raise(LoadError, "Unable to find jenkins module in modulepath #{Puppet[:basemodulepath] || Puppet[:modulepath]}") unless jenkins
+  require File.join jenkins.path, 'lib/puppet_x/jenkins/config'
+end
 
-module PuppetX::Jenkins::Type::Cli
-  def self.newtype(*args, &block)
-    type = Puppet::Type.newtype(*args, &block)
+module PuppetX
+  module Jenkins
+    module Type
+      module Cli
+        def self.newtype(*args, &block)
+          type = Puppet::Type.newtype(*args, &block)
 
-    # The jenkins master needs to be avaiable in order to interact with it via
-    # the cli jar.
-    type.autorequire(:service) do
-      ['jenkins']
-    end
+          # The jenkins master needs to be avaiable in order to interact with it via
+          # the cli jar.
+          type.autorequire(:service) do
+            ['jenkins']
+          end
 
-    # If a file resource is declared for file path params, make sure that it's
-    # converged so we can read it off disk.
-    type.autorequire(:file) do
-      config = PuppetX::Jenkins::Config.new(catalog)
+          # If a file resource is declared for file path params, make sure that it's
+          # converged so we can read it off disk.
+          type.autorequire(:file) do
+            config = PuppetX::Jenkins::Config.new(catalog)
 
-      autos = []
-      %w( ssh_private_key puppet_helper ).each do |param|
-        value = config[param.to_sym]
-        autos << value unless value.nil?
+            autos = []
+            %w( ssh_private_key puppet_helper ).each do |param|
+              value = config[param.to_sym]
+              autos << value unless value.nil?
+            end
+
+            autos
+          end
+        end
       end
-
-      autos
     end
   end
 end

--- a/lib/puppet_x/jenkins/util.rb
+++ b/lib/puppet_x/jenkins/util.rb
@@ -1,31 +1,33 @@
-require 'puppet_x/jenkins'
-
-module PuppetX::Jenkins::Util
-  def unundef(data)
-    iterate(data) { |x| x == :undef ? nil : x }
-  end
-  module_function :unundef
-
-  def undefize(data)
-    iterate(data) { |x| x.nil? ? :undef : x }
-  end
-  module_function :undefize
-
-  # loosely based on
-  # https://stackoverflow.com/questions/16412013/iterate-nested-hash-that-contains-hash-and-or-array
-  def iterate(data, &block)
-    return data unless block_given?
-
-    case data
-    when Hash
-      data.each_with_object({}) do |(k,v), h|
-        h[k] = iterate(v, &block)
+module PuppetX
+  module Jenkins
+    module Util
+      def unundef(data)
+        iterate(data) { |x| x == :undef ? nil : x }
       end
-    when Array
-      data.collect { |v| iterate(v, &block) }
-    else
-      block.call data
+      module_function :unundef
+
+      def undefize(data)
+        iterate(data) { |x| x.nil? ? :undef : x }
+      end
+      module_function :undefize
+
+      # loosely based on
+      # https://stackoverflow.com/questions/16412013/iterate-nested-hash-that-contains-hash-and-or-array
+      def iterate(data, &block)
+        return data unless block_given?
+
+        case data
+        when Hash
+          data.each_with_object({}) do |(k,v), h|
+            h[k] = iterate(v, &block)
+          end
+        when Array
+          data.collect { |v| iterate(v, &block) }
+        else
+          block.call data
+        end
+      end
+      module_function :iterate
     end
   end
-  module_function :iterate
 end


### PR DESCRIPTION
When running under Puppet Server, attempting to load files from puppet_x
results in an autoload failure due to some stricter `$LOAD_PATH` rules. Whilst
certainly a bug upstream reworking the native types like this allows the module
to work under Puppet Server.

I haven't been able to test this when not running under Puppet Server as I don't have that available I'm afraid. The loading logic was shamelessly lifted from the `archive` module.