### PR TITLE
use ensure_packages() to manage the daemon package

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -113,10 +113,8 @@ class jenkins::slave (
     'Debian': {
       $defaults_location = '/etc/default'
 
-      package { 'daemon':
-        ensure => present,
-        before => Service['jenkins-slave'],
-      }
+      ensure_packages(['daemon'])
+      Package['daemon'] -> Service['jenkins-slave']
     }
     'Darwin': {
       $defaults_location = $slave_home

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -60,6 +60,8 @@ describe 'jenkins::slave' do
       let(:params) { { :slave_name => 'jenkins-slave' } }
       it_behaves_like 'using slave_name'
     end
+
+    it { should_not contain_package('daemon') }
   end
 
   describe 'Debian' do
@@ -72,6 +74,11 @@ describe 'jenkins::slave' do
     describe 'with slave_name' do
       let(:params) { { :slave_name => 'jenkins-slave' } }
       it_behaves_like 'using slave_name'
+    end
+
+    it do
+      should contain_package('daemon')
+        .that_comes_before('Service[jenkins-slave]')
     end
   end
 
@@ -93,6 +100,8 @@ describe 'jenkins::slave' do
       let(:params) { { :slave_name => 'jenkins-slave' } }
       it_behaves_like 'using slave_name'
     end
+
+    it { should_not contain_package('daemon') }
   end
 
   describe 'Unknown' do


### PR DESCRIPTION
`jenkins::slave` uses the `daemon` package on debian.  As this is a
commonly needed package, directly declaring a package resource may lead
to manifest conflicts.

closes #377