### PR TITLE
add user/group mgt. + localstatedir params to jenkins class

### DIFF
--- a/manifests/cli_helper.pp
+++ b/manifests/cli_helper.pp
@@ -20,8 +20,8 @@ class jenkins::cli_helper (
   $helper_groovy = "${libdir}/puppet_helper.groovy"
   file {$helper_groovy:
     source  => 'puppet:///modules/jenkins/puppet_helper.groovy',
-    owner   => 'jenkins',
-    group   => 'jenkins',
+    owner   => $::jenkins::user,
+    group   => $::jenkins::group,
     mode    => '0444',
     require => Class['jenkins::cli'],
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,14 +1,4 @@
-# Parameters:
-# config_hash = {} (Default)
-# Hash with config options to set in sysconfig/jenkins defaults/jenkins
-#
-# Example use
-#
-# class{ 'jenkins::config':
-#   config_hash => {
-#     'HTTP_PORT' => { 'value' => '9090' }, 'AJP_PORT' => { 'value' => '9009' }
-#   }
-# }
+# This class should be considered private
 #
 class jenkins::config {
 
@@ -17,4 +7,35 @@ class jenkins::config {
   }
 
   create_resources( 'jenkins::sysconfig', $::jenkins::config_hash )
+
+  $dir_params = {
+    ensure => directory,
+    owner  => $::jenkins::user,
+    group  => $::jenkins::group,
+    mode   => '0755',
+  }
+
+  # ensure_resource is used to try to maintain backwards compatiblity with
+  # manifests that were able to external declare resources due to the
+  # old conditional behavior of jenkins::plugin
+  if $::jenkins::manage_user {
+    ensure_resource('user', $::jenkins::user, {
+      ensure     => present,
+      gid        => $::jenkins::group,
+      home       => $::jenkins::localstatedir,
+      managehome => false,
+      system     => true,
+    })
+  }
+
+  if $::jenkins::manage_group {
+    ensure_resource('group', $::jenkins::group, {
+      ensure => present,
+      system => true,
+    })
+  }
+
+  ensure_resource('file', $::jenkins::localstatedir, $dir_params)
+  ensure_resource('file', $::jenkins::plugin_dir, $dir_params)
+  ensure_resource('file', $::jenkins::job_dir, $dir_params)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,11 +44,25 @@
 # config_hash = undef (Default)
 #   Hash with config options to set in sysconfig/jenkins defaults/jenkins
 #
+# localstatedir = '/var/lib/jenkins' (default)
+#   base path, in the autoconf sense, for jenkins local data including jobs and
+#   plugins
+#
 # executors = undef (Default)
 #   Integer number of executors on the Jenkin's master.
 #
 # slaveagentport = undef (Default)
 #   Integer number of portnumber for the slave agent.
+#
+# manage_user = true (default)
+#
+# user = 'jenkins' (default)
+#`  system user that owns the jenkins master's files
+#
+# manage_group = true (default)
+#
+# group = 'jenkins' (default)
+#`  system group that owns the jenkins master's files
 #
 # Example use
 #
@@ -146,6 +160,10 @@
 #   - Accepts input as array only.
 #   - Only effective if "proxy_host" and "proxy_port" are set.
 #
+# user = 'jenkins' (default)
+#
+# group = 'jenkins' (default)
+#
 #
 class jenkins(
   $version            = $jenkins::params::version,
@@ -173,8 +191,13 @@ class jenkins(
   $cli_try_sleep      = $jenkins::params::cli_try_sleep,
   $port               = $jenkins::params::port,
   $libdir             = $jenkins::params::libdir,
+  $localstatedir      = $::jenkins::params::localstatedir,
   $executors          = undef,
   $slaveagentport     = undef,
+  $manage_user        = $::jenkins::params::manage_user,
+  $user               = $::jenkins::params::user,
+  $manage_group       = $::jenkins::params::manage_group,
+  $group              = $::jenkins::params::group,
 ) inherits jenkins::params {
 
   validate_bool($lts, $install_java, $repo)
@@ -184,6 +207,8 @@ class jenkins(
     validate_bool($configure_firewall)
   }
 
+  validate_absolute_path($localstatedir)
+
   if $no_proxy_list {
     validate_array($no_proxy_list)
   }
@@ -191,6 +216,14 @@ class jenkins(
   if $executors {
     validate_integer($executors)
   }
+
+  validate_bool($manage_user)
+  validate_string($user)
+  validate_bool($manage_group)
+  validate_string($group)
+
+  $plugin_dir = "${localstatedir}/plugins"
+  $job_dir = "${localstatedir}/jobs"
 
   anchor {'jenkins::begin':}
   anchor {'jenkins::end':}

--- a/manifests/job/absent.pp
+++ b/manifests/job/absent.pp
@@ -20,7 +20,7 @@ define jenkins::job::absent(
   }
 
   $tmp_config_path  = "/tmp/${jobname}-config.xml"
-  $job_dir          = "/var/lib/jenkins/jobs/${jobname}"
+  $job_dir          = "${::jenkins::job_dir}/${jobname}"
   $config_path      = "${job_dir}/config.xml"
 
   # Temp file to use as stdin for Jenkins CLI executable

--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -27,7 +27,7 @@ define jenkins::job::present(
 
   $jenkins_cli        = $jenkins::cli::cmd
   $tmp_config_path    = "/tmp/${jobname}-config.xml"
-  $job_dir            = "/var/lib/jenkins/jobs/${jobname}"
+  $job_dir            = "${::jenkins::jobs_dir}/${jobname}"
   $config_path        = "${job_dir}/config.xml"
 
   # Bring variables from Class['::jenkins'] into local scope.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,12 @@ class jenkins::params {
   $cli_try_sleep         = 10
   $package_cache_dir     = '/var/cache/jenkins_pkgs'
   $package_name          = 'jenkins'
+  $localstatedir         = '/var/lib/jenkins'
+
+  $manage_user  = true
+  $user         = 'jenkins'
+  $manage_group = true
+  $group        = 'jenkins'
 
   case $::osfamily {
     'Debian': {
@@ -27,7 +33,7 @@ class jenkins::params {
       $package_provider = 'rpm'
     }
     default: {
-      $libdir = '/usr/lib/jenkins'
+      $libdir           = '/usr/lib/jenkins'
       $package_provider = false
     }
   }

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -10,10 +10,10 @@ class jenkins::proxy {
   $proxy_port = $::jenkins::proxy_port
   $no_proxy_list = $::jenkins::no_proxy_list
 
-  file { '/var/lib/jenkins/proxy.xml':
+  file { "${::jenkins::localstatedir}/proxy.xml":
     content => template('jenkins/proxy.xml.erb'),
-    owner   => 'jenkins',
-    group   => 'jenkins',
+    owner   => $::jenkins::user,
+    group   => $::jenkins::group,
     mode    => '0644'
   }
 

--- a/spec/classes/jenkins_cli_helper_spec.rb
+++ b/spec/classes/jenkins_cli_helper_spec.rb
@@ -13,5 +13,14 @@ describe 'jenkins::cli_helper', :type => :class do
         that_comes_before('Anchor[jenkins::end]')
     end
   end
+
+  it do
+    should contain_file('/usr/lib/jenkins/puppet_helper.groovy').with(
+      :source => 'puppet:///modules/jenkins/puppet_helper.groovy',
+      :owner  => 'jenkins',
+      :group  => 'jenkins',
+      :mode   => '0444',
+    )
+  end
 end
 

--- a/spec/classes/jenkins_master_spec.rb
+++ b/spec/classes/jenkins_master_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'jenkins::master' do
+  let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'CentOS' }}
 
   let(:params) { { :version => '1.2.3' } }
   it { should contain_jenkins__plugin('swarm').with_version('1.2.3') }

--- a/spec/classes/jenkins_proxy_spec.rb
+++ b/spec/classes/jenkins_proxy_spec.rb
@@ -11,7 +11,13 @@ describe 'jenkins', :type => :module do
     context 'with basic proxy config' do
       let(:params) { { :proxy_host => 'myhost', :proxy_port => 1234 } }
       it { should create_class('jenkins::proxy') }
-      it { should contain_file('/var/lib/jenkins/proxy.xml') }
+      it do
+        should contain_file('/var/lib/jenkins/proxy.xml').with(
+          :owner => 'jenkins',
+          :group => 'jenkins',
+          :mode  => '0644',
+        )
+      end
       it { should contain_file('/var/lib/jenkins/proxy.xml').with(:content => /<name>myhost<\/name>/) }
       it { should contain_file('/var/lib/jenkins/proxy.xml').with(:content => /<port>1234<\/port>/) }
       it { should contain_file('/var/lib/jenkins/proxy.xml').without(:content => /<noProxyHost>/) }
@@ -20,7 +26,13 @@ describe 'jenkins', :type => :module do
     context 'with "no_proxy_list" proxy config' do
       let(:params) { { :proxy_host => 'myhost', :proxy_port => 1234, :no_proxy_list => ['example.com','test.host.net'] } }
       it { should create_class('jenkins::proxy') }
-      it { should contain_file('/var/lib/jenkins/proxy.xml') }
+      it do
+        should contain_file('/var/lib/jenkins/proxy.xml').with(
+          :owner => 'jenkins',
+          :group => 'jenkins',
+          :mode  => '0644',
+        )
+      end
       it { should contain_file('/var/lib/jenkins/proxy.xml').with(:content => /<name>myhost<\/name>/) }
       it { should contain_file('/var/lib/jenkins/proxy.xml').with(:content => /<port>1234<\/port>/) }
       it { should contain_file('/var/lib/jenkins/proxy.xml').with(:content => /<noProxyHost>example\.com\ntest\.host\.net<\/noProxyHost>/) }

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -65,6 +65,22 @@ describe 'jenkins', :type => :module do
       it { expect { should raise_error(Puppet::Error) } }
     end
 
+    describe 'localstatedir =>' do
+      context 'undef' do
+        it { should contain_file('/var/lib/jenkins') }
+      end
+
+      context '/dne' do
+        let(:params) {{ :localstatedir => '/dne' }}
+        it { should contain_file('/dne') }
+      end
+
+      context './tmp' do
+        let(:params) {{ :localstatedir => './tmp' }}
+        it { should raise_error(Puppet::Error, /is not an absolute path/) }
+      end
+    end
+
     describe 'executors =>' do
       context 'undef' do
         it { should_not contain_class('jenkins::cli_helper') }
@@ -123,5 +139,136 @@ describe 'jenkins', :type => :module do
         end
       end
     end # slaveagentport =>
+
+    describe 'manage_user =>' do
+      context '(default)' do
+        it { should contain_user('jenkins') }
+      end
+
+      context 'true' do
+        let(:params) {{ :manage_user => true }}
+        it { should contain_user('jenkins') }
+      end
+
+      context 'false' do
+        let(:params) {{ :manage_user => false }}
+        it { should_not contain_user('jenkins') }
+      end
+
+      context '{}' do
+        let(:params) {{ :manage_user => {} }}
+
+        it 'should fail' do
+          should raise_error(Puppet::Error, /is not a boolean./)
+        end
+      end
+    end # manage_user =>
+
+    describe 'user =>' do
+      context '(default)' do
+        it do
+          should contain_user('jenkins').with(
+            :ensure     => 'present',
+            :gid        => 'jenkins',
+            :home       => '/var/lib/jenkins',
+            :managehome => false,
+            :system     => true,
+          )
+        end
+      end
+
+      context 'bob' do
+        let(:params) {{ :user => 'bob' }}
+
+        it do
+          should contain_user('bob').with(
+            :ensure     => 'present',
+            :gid        => 'jenkins',
+            :home       => '/var/lib/jenkins',
+            :managehome => false,
+            :system     => true,
+          )
+        end
+      end
+
+      context '{}' do
+        let(:params) {{ :user => {} }}
+
+        it 'should fail' do
+          should raise_error(Puppet::Error, /is not a string./)
+        end
+      end
+    end # user =>
+
+    describe 'manage_group =>' do
+      context '(default)' do
+        it { should contain_group('jenkins') }
+      end
+
+      context 'true' do
+        let(:params) {{ :manage_group => true }}
+        it { should contain_group('jenkins') }
+      end
+
+      context 'false' do
+        let(:params) {{ :manage_group => false }}
+        it { should_not contain_group('jenkins') }
+      end
+
+      context '{}' do
+        let(:params) {{ :manage_group => {} }}
+
+        it 'should fail' do
+          should raise_error(Puppet::Error, /is not a boolean./)
+        end
+      end
+    end # manage_group =>
+
+    describe 'group =>' do
+      context '(default)' do
+        it do
+          should contain_group('jenkins').with(
+            :ensure => 'present',
+            :system => true,
+          )
+        end
+      end
+
+      context 'fred' do
+        let(:params) {{ :group => 'fred' }}
+
+        it do
+          should contain_group('fred').with(
+            :ensure => 'present',
+            :system => true,
+          )
+        end
+      end
+
+      context '{}' do
+        let(:params) {{ :group => {} }}
+
+        it 'should fail' do
+          should raise_error(Puppet::Error, /is not a string./)
+        end
+      end
+    end # group =>
+
+    describe 'manages state dirs' do
+      [
+        '/var/lib/jenkins',
+        '/var/lib/jenkins/jobs',
+        '/var/lib/jenkins/plugins',
+      ].each do |dir|
+        it do
+          should contain_file(dir).with(
+            :ensure => 'directory',
+            :owner  => 'jenkins',
+            :group  => 'jenkins',
+            :mode   => '0755',
+          )
+        end
+      end
+    end # manages state dirs
   end
 end


### PR DESCRIPTION
* add `manager_user`, `user`, `manage_group`, `group` params to
  `jenkins` class.

* improve consistency of `file` resouce group ownership throughout
  the module

* add 'localstatedir' param to `jenkins` class and consistently use it
  to set the 'data' base dir throughout the module

* Deprecate/noop `username`, `group`, `create_user` params to
  `jenkins::plugin` define; replaced by `user`,`group`,etc. params to
  `jenkins` class

* Deprecate/noop `plugin_dir` param to `jenkins::plugin`; replaced by
  `localstatedir` param to `jenkins` class

closes #356 -- alternative approach
resolves #362
resolves #365
resolves #219 
resolves #249
resolves #250