### PR TITLE
fix job_dir variable reference to jenkins class

### DIFF
--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -27,7 +27,7 @@ define jenkins::job::present(
 
   $jenkins_cli        = $jenkins::cli::cmd
   $tmp_config_path    = "/tmp/${jobname}-config.xml"
-  $job_dir            = "${::jenkins::jobs_dir}/${jobname}"
+  $job_dir            = "${::jenkins::job_dir}/${jobname}"
   $config_path        = "${job_dir}/config.xml"
 
   # Bring variables from Class['::jenkins'] into local scope.


### PR DESCRIPTION
This seems to be just a minor typo, but it causes create job exec statements to fail the second time, since puppet would retry creating jobs. It cannot find the correct files because of the incomplete path.