### PR TITLE
Undefine create_user in plugins

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -29,7 +29,7 @@ define jenkins::plugin(
   $plugin_dir      = undef,
   $username        = undef,
   $group           = undef,
-  $create_user     = true,
+  $create_user     = undef,
 ) {
   include ::jenkins
 


### PR DESCRIPTION
When the manifest is applied, the jenkins::plugin logs a warning message about `create_user` being deprecated. Since it has no effect (according to the warning), I've switched its default value over to undef from true. This prevents the warning.