### PR TITLE
Allow the user to manage the localstatedir themselves.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,9 +35,6 @@ class jenkins::config {
     })
   }
 
-  if $::jenkins::manage_localstatedir {
-  }
-
   if $::jenkins::manage_datadirs {
     ensure_resource('file', $::jenkins::localstatedir, $dir_params)
     ensure_resource('file', $::jenkins::plugin_dir, $dir_params)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,7 +35,10 @@ class jenkins::config {
     })
   }
 
-  ensure_resource('file', $::jenkins::localstatedir, $dir_params)
+  if $::jenkins::manage_localstatedir {
+    ensure_resource('file', $::jenkins::localstatedir, $dir_params)
+  }
+
   ensure_resource('file', $::jenkins::plugin_dir, $dir_params)
   ensure_resource('file', $::jenkins::job_dir, $dir_params)
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,9 +36,11 @@ class jenkins::config {
   }
 
   if $::jenkins::manage_localstatedir {
-    ensure_resource('file', $::jenkins::localstatedir, $dir_params)
   }
 
-  ensure_resource('file', $::jenkins::plugin_dir, $dir_params)
-  ensure_resource('file', $::jenkins::job_dir, $dir_params)
+  if $::jenkins::manage_datadirs {
+    ensure_resource('file', $::jenkins::localstatedir, $dir_params)
+    ensure_resource('file', $::jenkins::plugin_dir, $dir_params)
+    ensure_resource('file', $::jenkins::job_dir, $dir_params)
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,12 +44,18 @@
 # config_hash = undef (Default)
 #   Hash with config options to set in sysconfig/jenkins defaults/jenkins
 #
-# manage_localstatedir = true (default)
-#   true if this module should manage the localstatedir
+# manage_datadirs = true (default)
+#   true if this module should manage the local state dir, plugins dir and jobs dir
 #
 # localstatedir = '/var/lib/jenkins' (default)
 #   base path, in the autoconf sense, for jenkins local data including jobs and
 #   plugins
+#
+# plugin_dir = '/var/lib/jenkins/plugins' (default)
+#   absolute path for jenkins plugins directory
+#
+# job_dir = '/var/lib/jenkins/jobs' (default)
+#   absolute path for jenkins jobs directory
 #
 # executors = undef (Default)
 #   Integer number of executors on the Jenkin's master.
@@ -169,39 +175,41 @@
 #
 #
 class jenkins(
-  $version              = $jenkins::params::version,
-  $lts                  = $jenkins::params::lts,
-  $repo                 = $jenkins::params::repo,
-  $package_name         = $jenkins::params::package_name,
-  $direct_download      = false,
-  $package_cache_dir    = $jenkins::params::package_cache_dir,
-  $package_provider     = $jenkins::params::package_provider,
-  $service_enable       = $jenkins::params::service_enable,
-  $service_ensure       = $jenkins::params::service_ensure,
-  $config_hash          = {},
-  $plugin_hash          = {},
-  $job_hash             = {},
-  $user_hash            = {},
-  $configure_firewall   = undef,
-  $install_java         = $jenkins::params::install_java,
-  $repo_proxy           = undef,
-  $proxy_host           = undef,
-  $proxy_port           = undef,
-  $no_proxy_list        = undef,
-  $cli                  = undef,
-  $cli_ssh_keyfile      = undef,
-  $cli_tries            = $jenkins::params::cli_tries,
-  $cli_try_sleep        = $jenkins::params::cli_try_sleep,
-  $port                 = $jenkins::params::port,
-  $libdir               = $jenkins::params::libdir,
-  $manage_localstatedir = $jenkins::params::manage_localstatedir,
-  $localstatedir        = $::jenkins::params::localstatedir,
-  $executors            = undef,
-  $slaveagentport       = undef,
-  $manage_user          = $::jenkins::params::manage_user,
-  $user                 = $::jenkins::params::user,
-  $manage_group         = $::jenkins::params::manage_group,
-  $group                = $::jenkins::params::group,
+  $version            = $jenkins::params::version,
+  $lts                = $jenkins::params::lts,
+  $repo               = $jenkins::params::repo,
+  $package_name       = $jenkins::params::package_name,
+  $direct_download    = false,
+  $package_cache_dir  = $jenkins::params::package_cache_dir,
+  $package_provider   = $jenkins::params::package_provider,
+  $service_enable     = $jenkins::params::service_enable,
+  $service_ensure     = $jenkins::params::service_ensure,
+  $config_hash        = {},
+  $plugin_hash        = {},
+  $job_hash           = {},
+  $user_hash          = {},
+  $configure_firewall = undef,
+  $install_java       = $jenkins::params::install_java,
+  $repo_proxy         = undef,
+  $proxy_host         = undef,
+  $proxy_port         = undef,
+  $no_proxy_list      = undef,
+  $cli                = undef,
+  $cli_ssh_keyfile    = undef,
+  $cli_tries          = $jenkins::params::cli_tries,
+  $cli_try_sleep      = $jenkins::params::cli_try_sleep,
+  $port               = $jenkins::params::port,
+  $libdir             = $jenkins::params::libdir,
+  $manage_datadirs    = $jenkins::params::manage_datadirs,
+  $localstatedir      = $::jenkins::params::localstatedir,
+  $plugin_dir         = $::jenkins::params::plugin_dir,
+  $job_dir            = $::jenkins::params::job_dir,
+  $executors          = undef,
+  $slaveagentport     = undef,
+  $manage_user        = $::jenkins::params::manage_user,
+  $user               = $::jenkins::params::user,
+  $manage_group       = $::jenkins::params::manage_group,
+  $group              = $::jenkins::params::group,
 ) inherits jenkins::params {
 
   validate_bool($lts, $install_java, $repo)
@@ -211,8 +219,10 @@ class jenkins(
     validate_bool($configure_firewall)
   }
 
-  validate_bool($manage_localstatedir)
+  validate_bool($manage_datadirs)
   validate_absolute_path($localstatedir)
+  validate_absolute_path($plugin_dir)
+  validate_absolute_path($job_dir)
 
   if $no_proxy_list {
     validate_array($no_proxy_list)
@@ -226,9 +236,6 @@ class jenkins(
   validate_string($user)
   validate_bool($manage_group)
   validate_string($group)
-
-  $plugin_dir = "${localstatedir}/plugins"
-  $job_dir = "${localstatedir}/jobs"
 
   anchor {'jenkins::begin':}
   anchor {'jenkins::end':}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,9 @@
 # config_hash = undef (Default)
 #   Hash with config options to set in sysconfig/jenkins defaults/jenkins
 #
+# manage_localstatedir = true (default)
+#   true if this module should manage the localstatedir
+#
 # localstatedir = '/var/lib/jenkins' (default)
 #   base path, in the autoconf sense, for jenkins local data including jobs and
 #   plugins
@@ -166,38 +169,39 @@
 #
 #
 class jenkins(
-  $version            = $jenkins::params::version,
-  $lts                = $jenkins::params::lts,
-  $repo               = $jenkins::params::repo,
-  $package_name       = $jenkins::params::package_name,
-  $direct_download    = false,
-  $package_cache_dir  = $jenkins::params::package_cache_dir,
-  $package_provider   = $jenkins::params::package_provider,
-  $service_enable     = $jenkins::params::service_enable,
-  $service_ensure     = $jenkins::params::service_ensure,
-  $config_hash        = {},
-  $plugin_hash        = {},
-  $job_hash           = {},
-  $user_hash          = {},
-  $configure_firewall = undef,
-  $install_java       = $jenkins::params::install_java,
-  $repo_proxy         = undef,
-  $proxy_host         = undef,
-  $proxy_port         = undef,
-  $no_proxy_list      = undef,
-  $cli                = undef,
-  $cli_ssh_keyfile    = undef,
-  $cli_tries          = $jenkins::params::cli_tries,
-  $cli_try_sleep      = $jenkins::params::cli_try_sleep,
-  $port               = $jenkins::params::port,
-  $libdir             = $jenkins::params::libdir,
-  $localstatedir      = $::jenkins::params::localstatedir,
-  $executors          = undef,
-  $slaveagentport     = undef,
-  $manage_user        = $::jenkins::params::manage_user,
-  $user               = $::jenkins::params::user,
-  $manage_group       = $::jenkins::params::manage_group,
-  $group              = $::jenkins::params::group,
+  $version              = $jenkins::params::version,
+  $lts                  = $jenkins::params::lts,
+  $repo                 = $jenkins::params::repo,
+  $package_name         = $jenkins::params::package_name,
+  $direct_download      = false,
+  $package_cache_dir    = $jenkins::params::package_cache_dir,
+  $package_provider     = $jenkins::params::package_provider,
+  $service_enable       = $jenkins::params::service_enable,
+  $service_ensure       = $jenkins::params::service_ensure,
+  $config_hash          = {},
+  $plugin_hash          = {},
+  $job_hash             = {},
+  $user_hash            = {},
+  $configure_firewall   = undef,
+  $install_java         = $jenkins::params::install_java,
+  $repo_proxy           = undef,
+  $proxy_host           = undef,
+  $proxy_port           = undef,
+  $no_proxy_list        = undef,
+  $cli                  = undef,
+  $cli_ssh_keyfile      = undef,
+  $cli_tries            = $jenkins::params::cli_tries,
+  $cli_try_sleep        = $jenkins::params::cli_try_sleep,
+  $port                 = $jenkins::params::port,
+  $libdir               = $jenkins::params::libdir,
+  $manage_localstatedir = $jenkins::params::manage_localstatedir,
+  $localstatedir        = $::jenkins::params::localstatedir,
+  $executors            = undef,
+  $slaveagentport       = undef,
+  $manage_user          = $::jenkins::params::manage_user,
+  $user                 = $::jenkins::params::user,
+  $manage_group         = $::jenkins::params::manage_group,
+  $group                = $::jenkins::params::group,
 ) inherits jenkins::params {
 
   validate_bool($lts, $install_java, $repo)
@@ -207,6 +211,7 @@ class jenkins(
     validate_bool($configure_firewall)
   }
 
+  validate_bool($manage_localstatedir)
   validate_absolute_path($localstatedir)
 
   if $no_proxy_list {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,9 @@ class jenkins::params {
   $cli_try_sleep         = 10
   $package_cache_dir     = '/var/cache/jenkins_pkgs'
   $package_name          = 'jenkins'
-  $localstatedir         = '/var/lib/jenkins'
+
+  $manage_localstatedir = true
+  $localstatedir        = '/var/lib/jenkins'
 
   $manage_user  = true
   $user         = 'jenkins'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,8 +17,10 @@ class jenkins::params {
   $package_cache_dir     = '/var/cache/jenkins_pkgs'
   $package_name          = 'jenkins'
 
-  $manage_localstatedir = true
-  $localstatedir        = '/var/lib/jenkins'
+  $manage_datadirs = true
+  $localstatedir   = '/var/lib/jenkins'
+  $plugin_dir      = "${localstatedir}/plugins"
+  $job_dir         = "${localstatedir}/jobs"
 
   $manage_user  = true
   $user         = 'jenkins'

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -65,10 +65,17 @@ describe 'jenkins', :type => :module do
       it { expect { should raise_error(Puppet::Error) } }
     end
 
-    describe 'manage_localstatedir =>' do
+    describe 'manage_datadirs =>' do
       context 'false' do
-        let(:params) {{ :manage_localstatedir => false }}
+        let(:params) {{ :manage_datadirs => false }}
         it { should_not contain_file('/var/lib/jenkins') }
+        it { should_not contain_file('/var/lib/jenkins/plugins') }
+        it { should_not contain_file('/var/lib/jenkins/jobs') }
+      end
+
+      context '"false"' do
+        let(:params) {{ :manage_datadirs => "false" }}
+        it { should raise_error(Puppet::Error, /is not a boolean/) }
       end
 
       context '(default)' do
@@ -88,6 +95,38 @@ describe 'jenkins', :type => :module do
 
       context './tmp' do
         let(:params) {{ :localstatedir => './tmp' }}
+        it { should raise_error(Puppet::Error, /is not an absolute path/) }
+      end
+    end
+
+    describe 'plugin_dir =>' do
+      context '(default)' do
+        it { should contain_file('/var/lib/jenkins/plugins') }
+      end
+
+      context '/var/lib/jenkins/pd' do
+        let(:params) {{ :plugin_dir => '/var/lib/jenkins/pd' }}
+        it { should contain_file('/var/lib/jenkins/pd') }
+      end
+
+      context './pd' do
+        let(:params) {{ :plugin_dir => './pd' }}
+        it { should raise_error(Puppet::Error, /is not an absolute path/) }
+      end
+    end
+
+    describe 'job_dir =>' do
+      context '(default)' do
+        it { should contain_file('/var/lib/jenkins/jobs') }
+      end
+
+      context '/var/lib/jenkins/jd' do
+        let(:params) {{ :job_dir => '/var/lib/jenkins/jd' }}
+        it { should contain_file('/var/lib/jenkins/jd') }
+      end
+
+      context './jd' do
+        let(:params) {{ :job_dir => './jd' }}
         it { should raise_error(Puppet::Error, /is not an absolute path/) }
       end
     end

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -65,6 +65,17 @@ describe 'jenkins', :type => :module do
       it { expect { should raise_error(Puppet::Error) } }
     end
 
+    describe 'manage_localstatedir =>' do
+      context 'false' do
+        let(:params) {{ :manage_localstatedir => false }}
+        it { should_not contain_file('/var/lib/jenkins') }
+      end
+
+      context '(default)' do
+        it { should contain_file('/var/lib/jenkins') }
+      end
+    end
+
     describe 'localstatedir =>' do
       context 'undef' do
         it { should contain_file('/var/lib/jenkins') }


### PR DESCRIPTION
* add `manage_localstatedir` param to `jenkins class
* align params on equal sign.
* validate that manage_localstatedir is a bool.
* add documentation for manage_localstatedir.

When localstatedir is a symlink to a mount, the user may want to manage that outside of this module.