### PR TITLE
Check if the retries gem is not already declared

### DIFF
--- a/manifests/cli/config.pp
+++ b/manifests/cli/config.pp
@@ -24,8 +24,10 @@ class jenkins::cli::config(
   validate_string($ssh_private_key_content)
 
   # required by PuppetX::Jenkins::Provider::Clihelper base
-  package { 'retries':
-    provider => 'gem',
+  if ! defined(Package['retries']) {
+    package { 'retries':
+      provider => 'gem',
+    }
   }
 
   if $ssh_private_key and $ssh_private_key_content {


### PR DESCRIPTION
The main motivation for this is handling the retries gem installation when it is already defined in the catalog. 
This is needed if one has to use a different provider. For example for Puppet 4 to install the retries gem successfully one needs to use the 'puppet_gem' provider. 
Alternative solution would be to handle this in the module directly.