### PR TITLE
Improvements to job type

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -875,6 +875,24 @@ class Actions {
     def disabled = Jenkins.getInstance().getJob(name).isDisabled()
     out.println(!disabled)
   }
+
+  /////////////////////////
+  // get_job_list
+  /////////////////////////
+  /*
+   * Return all the configured jobs as a list of maps
+   */
+  void get_job_list() {
+    def jobs = []
+    Jenkins.getInstance().items.each { job ->
+      def name = job.getName()
+      jobs << [name: name, config: job.getConfigFile().getFile().getText('utf-8'), enabled: !job.isDisabled()]
+    }
+
+    def builder = new groovy.json.JsonBuilder(jobs)
+    out.println(builder.toPrettyString())
+  }
+
 } // class Actions
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/lib/puppet/provider/jenkins_job/cli.rb
+++ b/lib/puppet/provider/jenkins_job/cli.rb
@@ -8,19 +8,13 @@ Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provi
   mk_resource_methods
 
   def self.instances(catalog = nil)
-    job_names = list_jobs(catalog)
-
-    Puppet.debug("#{sname} instances: #{job_names}")
-
-    # XXX iterating over each job is slow because it requires 2 invocations of
-    # the cli jar.  This should be replaced with a puppet_helper method to
-    # return the configuration for all jobs at once.
-    job_names.collect do |job|
+    jobs = get_jobs(catalog)
+    jobs.collect do |job|
       new(
-        :name   => job,
+        :name   => job['name'],
         :ensure => :present,
-        :config => get_job(job, catalog),
-        :enable => job_enabled(job, catalog),
+        :config => job['config'],
+        :enable => job['enabled'],
       )
     end
   end
@@ -63,6 +57,11 @@ Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provi
     cli(['list-jobs'], :catalog => catalog).split
   end
   private_class_method :list_jobs
+
+  def self.get_jobs(catalog = nil)
+    cli(['get_job_list'], :catalog => catalog)
+  end
+  private_class_method :get_jobs
 
   def self.get_job(job, catalog = nil)
     cli(['get-job', job], :catalog => catalog)

--- a/lib/puppet/provider/jenkins_job/cli.rb
+++ b/lib/puppet/provider/jenkins_job/cli.rb
@@ -59,7 +59,7 @@ Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provi
   private_class_method :list_jobs
 
   def self.get_jobs(catalog = nil)
-    cli(['groovy', 'get_job_list'], :catalog => catalog)
+    clihelper(['get_job_list'], :catalog => catalog)
   end
   private_class_method :get_jobs
 

--- a/lib/puppet/provider/jenkins_job/cli.rb
+++ b/lib/puppet/provider/jenkins_job/cli.rb
@@ -59,7 +59,13 @@ Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provi
   private_class_method :list_jobs
 
   def self.get_jobs(catalog = nil)
-    clihelper(['get_job_list'], :catalog => catalog)
+    raw = clihelper(['get_job_list'], :catalog => catalog)
+
+    begin
+      JSON.parse(raw)
+    rescue JSON::ParserError
+      fail("unable to parse as JSON: #{raw}")
+    end
   end
   private_class_method :get_jobs
 

--- a/lib/puppet/provider/jenkins_job/cli.rb
+++ b/lib/puppet/provider/jenkins_job/cli.rb
@@ -59,7 +59,7 @@ Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provi
   private_class_method :list_jobs
 
   def self.get_jobs(catalog = nil)
-    cli(['get_job_list'], :catalog => catalog)
+    cli(['groovy', 'get_job_list'], :catalog => catalog)
   end
   private_class_method :get_jobs
 

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -14,10 +14,6 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
     isnamevar
   end
 
-  newproperty(:checksum) do
-    desc 'The checksum of the XML job configuration'
-  end
-
   newproperty(:config) do
     include Puppet::Util::Diff
     include Puppet::Util::Checksums
@@ -33,12 +29,18 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
         current_md5 = Digest::MD5.hexdigest(currentvalue)
         new_md5 = Digest::MD5.hexdigest(newvalue)
 
-        Puppet.notice(lcs_diff(currentvalue, newvalue))
+        if Puppet[:show_diff] and resource.parameter(:show_diff)
+          send @resource[:loglevel], "\n" + lcs_diff(currentvalue, newvalue)
+        end
 
         return "content changed '{md5}#{current_md5}' to '{md5}#{new_md5}'"
       end
     end
+  end
 
+  newparam(:show_diff, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc 'enable/disable displaying configuration diff'
+    defaultto true
   end
 
   newproperty(:enable, :boolean => true, :parent => Puppet::Property::Boolean) do

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -1,6 +1,6 @@
-require 'digest/md5'
 require 'puppet/property/boolean'
 require 'puppet/util/diff'
+require 'puppet/util/checksums'
 
 require 'puppet_x/jenkins/type/cli'
 
@@ -26,13 +26,12 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
       elsif newvalue == :absent
         return "removed"
       else
-        current_md5 = Digest::MD5.hexdigest(currentvalue)
-        new_md5 = Digest::MD5.hexdigest(newvalue)
-
         if Puppet[:show_diff] and resource.parameter(:show_diff)
           send @resource[:loglevel], "\n" + lcs_diff(currentvalue, newvalue)
         end
 
+        current_md5 = md5(currentvalue)
+        new_md5 = md5(newvalue)
         return "content changed '{md5}#{current_md5}' to '{md5}#{new_md5}'"
       end
     end

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -27,7 +27,7 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
         current_md5 = Digest::MD5.hexdigest(currentvalue)
         new_md5 = Digest::MD5.hexdigest(newvalue)
 
-        Puppet.notice(Puppet::Util::Diff.lcs_diff(currentvalue, newvalue))
+        Puppet.notice(Puppet::Util::Diff.diff(currentvalue, newvalue))
 
         return "content changed '{md5}#{current_md5}' to '{md5}#{new_md5}'"
       end

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -1,5 +1,6 @@
-require 'digest'
+require 'digest/md5'
 require 'puppet/property/boolean'
+require 'puppet/util/diff'
 
 require 'puppet_x/jenkins/type/cli'
 
@@ -25,6 +26,9 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
       else
         current_md5 = Digest::MD5.hexdigest(currentvalue)
         new_md5 = Digest::MD5.hexdigest(newvalue)
+
+        Puppet.notice(Puppet::Util::Diff.lcs_diff(currentvalue, newvalue))
+
         return "content changed '{md5}#{current_md5}' to '{md5}#{new_md5}'"
       end
     end

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -22,8 +22,6 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
     include Puppet::Util::Diff
     include Puppet::Util::Checksums
 
-#    attr_reader :actual_content
-
     desc 'XML job configuration string'
 
 #    munge do |value|
@@ -53,14 +51,6 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
       end
     end
 
-    def content
-      self.should
-    end
-
-    def insync?(is)
-      result = super
-      if ! result and Puppet[:show_diff] and resource.show_diff?
-    end
   end
 
   newproperty(:show_diff, :boolean => true, :parent => Puppet::Property::Boolean) do

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -24,18 +24,6 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
 
     desc 'XML job configuration string'
 
-#    munge do |value|
-#      if value == :absent
-#        value
-#      elsif checksum?(value)
-#        value
-#      else
-#        @actual_content = value
-#        resource.parameter(:checksum).sum(value)
-#      end
-#    end
-
-    # TODO: see if it's possible to log a diff of the change before
     def change_to_s(currentvalue, newvalue)
       if currentvalue == :absent
         return "created"
@@ -51,11 +39,6 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
       end
     end
 
-  end
-
-  newproperty(:show_diff, :boolean => true, :parent => Puppet::Property::Boolean) do
-    desc 'display a diff of the changes to job configuration'
-    defaultto true
   end
 
   newproperty(:enable, :boolean => true, :parent => Puppet::Property::Boolean) do

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -1,3 +1,4 @@
+require 'digest'
 require 'puppet/property/boolean'
 
 require 'puppet_x/jenkins/type/cli'
@@ -14,6 +15,19 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
 
   newproperty(:config) do
     desc 'XML job configuration string'
+
+    # TODO: see if it's possible to log a diff of the change before
+    def change_to_s(currentvalue, newvalue)
+      if currentvalue == :absent
+        return "created"
+      elsif newvalue == :absent
+        return "removed"
+      else
+        current_md5 = Digest::MD5.hexdigest(currentvalue)
+        new_md5 = Digest::MD5.hexdigest(newvalue)
+        return "content changed '{md5}#{current_md5}' to '{md5}#{new_md5}'"
+      end
+    end
   end
 
   newproperty(:enable, :boolean => true, :parent => Puppet::Property::Boolean) do

--- a/spec/unit/puppet/type/jenkins_job_spec.rb
+++ b/spec/unit/puppet/type/jenkins_job_spec.rb
@@ -1,12 +1,64 @@
 require 'spec_helper'
 require 'unit/puppet_x/spec_jenkins_types'
 
+TEST_CONFIG1 = <<'EOS'
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>test job</description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>/usr/bin/true</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>
+EOS
+
+TEST_CONFIG2 = <<'EOS'
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>test job</description>
+  <keepDependencies>true</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>true</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>true</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>/usr/bin/true</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>
+EOS
+
 describe Puppet::Type.type(:jenkins_job) do
   before(:each) { Facter.clear }
 
   describe 'parameters' do
     describe 'name' do
       it_behaves_like 'generic namevar', :name
+    end
+
+    describe 'show_diff' do
+      it_behaves_like 'boolean property', :show_diff, true
     end
   end #parameters
 
@@ -19,12 +71,35 @@ describe Puppet::Type.type(:jenkins_job) do
       it_behaves_like 'boolean property', :enable, true
     end
 
-    # unvalidated properties
-    [:config].each do |property|
-      describe "#{property}" do
-        it { expect(described_class.attrtype(property)).to eq :property }
+    describe 'config' do
+      let(:config) { described_class.new(:resource => resource) }
+
+      it { expect(described_class.attrtype('config')).to eq :config }
+
+      [true, false].product([true, false]).each do |cfg, param|
+        describe "and Puppet[:show_diff] is #{cfg} and show_diff => #{param}" do
+          before do
+            Puppet[:show_diff] = cfg
+            resource.stubs(:show_diff?).returns param
+            resource[:loglevel] = "debug"
+          end
+
+          if cfg and param
+            it "should display a diff" do
+              config.expects(:diff).returns("my diff").once
+              config.expects(:debug).with("\nmy diff").once
+              expect(content).not_to be_safe_insync("other content")
+            end
+          else
+            it "should not display a diff" do
+              config.expects(:diff).never
+              expect(content).not_to_be_safe_insync("other content")
+            end
+          end
+        end
       end
     end
+
   end #properties
 
   describe 'autorequire' do


### PR DESCRIPTION
This implements the method as mentioned in the comments previously in the type to return all the jobs in one go.

It also adds support for printing a checksum of the config change, and a diff.