### PR TITLE
Fix Plugin Download Timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ If you need to peg a specific version, simply specify that as a string, i.e.:
   }
 ```
 
+Note that plugin will timeout if it takes longer than 120 seconds to download.
+You can increase this by specifying a timeout value, i.e: `timeout => 240`.
+
 #### Verifying
 
 This module will download the jenkins modules over HTTP, without SSL.

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -25,6 +25,7 @@ define jenkins::plugin(
   $source          = undef,
   $digest_string   = '',
   $digest_type     = 'sha1',
+  $timeout         = 120,
   # deprecated
   $plugin_dir      = undef,
   $username        = undef,
@@ -125,6 +126,7 @@ define jenkins::plugin(
       proxy_server     => $proxy_server,
       notify           => Service['jenkins'],
       require          => File[$::jenkins::plugin_dir],
+      timeout          => $timeout,
     }
 
     file { "${::jenkins::plugin_dir}/${plugin}" :


### PR DESCRIPTION
When downloading large plugins, it can timeout (e.g. ruby-runtime). The
archive::download supports a timeout value which defaults to 120
seconds, but this plugin class doesn’t have any support to override
this value. This allows for the ability to adjust the timeout value for
large plugins.

Error message when download timeout exceeds 120 seconds:

Error:
/Stage[main]/Jenkins::Plugins/Jenkins::Plugin[ruby-runtime]/Archive::Dow
nload[ruby-runtime.hpi]/Exec[download archive ruby-runtime.hpi and
check sum]/returns: change from notrun to 0 failed: Command exceeded
timeout