### PR TITLE
Suppress notice messages when using archive::download

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -119,6 +119,7 @@ define jenkins::plugin(
       src_target       => $::jenkins::plugin_dir,
       allow_insecure   => true,
       follow_redirects => true,
+      verbose          => false,
       checksum         => $checksum,
       digest_string    => $digest_string,
       digest_type      => $digest_type,


### PR DESCRIPTION
The `verbose` attribute of the `archive::download` resource defaults to `true`.

This causes a notice message, `no checksum for this archive`, to be spammed to the terminal when `archive::download` is called without setting the checksum attribute.

This PR suppresses this notice.