### PR TITLE
More flexibility for setup

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@ class jenkins::config {
     owner  => $::jenkins::user,
     group  => $::jenkins::group,
     mode   => '0755',
+    links  => follow,
   }
 
   # ensure_resource is used to try to maintain backwards compatiblity with

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -59,7 +59,7 @@ define jenkins::plugin(
       undef   => $::jenkins::default_plugins_host,
       default => $update_url,
     }
-    $base_url = "${plugins_host}/download/plugins/${name}/${version}/"
+    $base_url = "${plugins_host}/plugins/${name}/${version}/"
     $search   = "${name} ${version}(,|$)"
   }
   else {


### PR DESCRIPTION
removed 'download' from plugin base_url to be more flexible. We have, for example, an artifactory repository as mirror for both jenkins.war files and plugins. The plugin files are in the path: http://servername/artifactory/jenkins-update/plugins. So no download part here.
Mind you that the fix is not backward compatible. I could do this if you want.
Current implementation breaks the Jenkins installation when a symbolic link is used for the plugins or jobs folder. In such case the symbolic link is removed and replaced by an actual folder, effectively removing all jobs from Jenkins \o/.
I added a parameter to follow links in config for setup to enable links for jobs and plugins folder.