### PR TITLE
Replace camptocamp/archive with puppet-community/puppet-archive

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,6 @@ fixtures:
     java: "https://github.com/puppetlabs/puppetlabs-java"
     zypprepo: "https://github.com/deadpoint/puppet-zypprepo.git"
     staging: "https://github.com/nanliu/puppet-staging"
-    archive: "https://github.com/camptocamp/puppet-archive"
+    archive: "https://github.com/puppet-community/puppet-archive.git"
   symlinks:
     "jenkins": "#{source_dir}"

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -105,7 +105,7 @@ define jenkins::plugin(
     file { "${::jenkins::plugin_dir}/${plugin}.pinned":
       owner   => $::jenkins::user,
       group   => $::jenkins::group,
-      require => Archive::Download[$plugin],
+      require => Archive["${::jenkins::plugin_dir}/${plugin}"],
     }
 
     if $digest_string == '' {
@@ -114,20 +114,13 @@ define jenkins::plugin(
       $checksum = true
     }
 
-    archive::download { $plugin:
-      url              => $download_url,
-      src_target       => $::jenkins::plugin_dir,
-      allow_insecure   => true,
-      follow_redirects => true,
-      verbose          => false,
-      checksum         => $checksum,
-      digest_string    => $digest_string,
-      digest_type      => $digest_type,
-      user             => $::jenkins::user,
-      proxy_server     => $proxy_server,
-      notify           => Service['jenkins'],
-      require          => File[$::jenkins::plugin_dir],
-      timeout          => $timeout,
+    archive { "${::jenkins::plugin_dir}/${plugin}":
+      source          => $download_url,
+      checksum_verify => $checksum,
+      checksum        => $digest_string,
+      checksum_type   => $digest_type,
+      notify          => Service['jenkins'],
+      require         => File[$::jenkins::plugin_dir],
     }
 
     file { "${::jenkins::plugin_dir}/${plugin}" :

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -119,6 +119,7 @@ define jenkins::plugin(
       checksum_verify => $checksum,
       checksum        => $digest_string,
       checksum_type   => $digest_type,
+      proxy_server    => $proxy_server,
       notify          => Service['jenkins'],
       require         => File[$::jenkins::plugin_dir],
     }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -119,6 +119,7 @@ define jenkins::plugin(
       src_target       => $::jenkins::plugin_dir,
       allow_insecure   => true,
       follow_redirects => true,
+      verbose          => false,
       checksum         => $checksum,
       digest_string    => $digest_string,
       digest_type      => $digest_type,

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,6 @@
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" },
-    { "name": "camptocamp/archive", "version_requirement": ">= 0.8.0" }
+    { "name": "puppetcommunity/puppet-archive", "version_requirement": ">= 0.3.0" }
   ]
 }

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -74,7 +74,7 @@ describe 'jenkins::plugin' do
     ]}
 
     it do
-      should contain_archive__download('myplug.hpi').with(
+      should contain_archive('myplug.hpi').with(
         :proxy_server => "proxy.company.com:8080",
       )
     end

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -6,9 +6,8 @@ describe 'jenkins::plugin' do
 
   describe 'without version' do
     it do
-      should contain_archive__download('myplug.hpi').with(
-        :url  =>  'https://updates.jenkins-ci.org/latest/myplug.hpi',
-        :user => 'jenkins',
+      should contain_archive('/var/lib/jenkins/plugins/myplug.hpi').with(
+        :source  =>  'https://updates.jenkins-ci.org/latest/myplug.hpi',
       )
     end
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
@@ -18,9 +17,8 @@ describe 'jenkins::plugin' do
     let(:params) { { :version => '1.2.3' } }
 
     it do
-      should contain_archive__download('myplug.hpi').with(
-        :url  =>  'https://updates.jenkins-ci.org/download/plugins/myplug/1.2.3/myplug.hpi',
-        :user => 'jenkins',
+      should contain_archive('/var/lib/jenkins/plugins/myplug.hpi').with(
+        :source  =>  'https://updates.jenkins-ci.org/download/plugins/myplug/1.2.3/myplug.hpi',
       )
     end
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
@@ -30,7 +28,7 @@ describe 'jenkins::plugin' do
     let(:params) { { :version => '1.2.3' } }
     before { facts[:jenkins_plugins] = 'myplug 1.2.3, fooplug 1.4.5' }
 
-    it { should_not contain_archive__download('myplug.hpi') }
+    it { should_not contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
     it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
   end
 
@@ -38,14 +36,14 @@ describe 'jenkins::plugin' do
     let(:params) { { :version => '1.2.3' } }
     before { facts[:jenkins_plugins] = 'fooplug 1.4.5, myplug 1.2.3' }
 
-    it { should_not contain_archive__download('myplug.hpi') }
+    it { should_not contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
     it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
   end
 
   describe 'with enabled is false' do
     let(:params) { { :enabled => false } }
 
-    it { should contain_archive__download('myplug.hpi') }
+    it { should contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi.disabled').with({
       :ensure => 'present',
@@ -57,7 +55,7 @@ describe 'jenkins::plugin' do
   describe 'with enabled is true' do
     let(:params) { { :enabled => true } }
 
-    it { should contain_archive__download('myplug.hpi') }
+    it { should contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi.disabled').with({
       :ensure => 'absent',
@@ -66,27 +64,11 @@ describe 'jenkins::plugin' do
     })}
   end
 
-  describe 'with proxy' do
-    let(:pre_condition) { [
-      'class jenkins {
-        $proxy_host = "proxy.company.com"
-        $proxy_port = 8080
-      }',
-      'include jenkins'
-    ]}
-
-    it do
-      should contain_archive__download('myplug.hpi').with(
-        :proxy_server => "proxy.company.com:8080",
-      )
-    end
-  end
-
   describe 'with a custom update center' do
     shared_examples 'execute the right fetch command' do
       it 'should retrieve the plugin' do
-        expect(subject).to contain_archive__download('git.hpi').with({
-          :url => "#{expected_url}",
+        expect(subject).to contain_archive('/var/lib/jenkins/plugins/git.hpi').with({
+          :source => "#{expected_url}",
         })
       end
     end
@@ -140,9 +122,8 @@ describe 'jenkins::plugin' do
   describe 'source' do
     shared_examples 'should download from $source url' do
       it 'should download from $source url' do
-         should contain_archive__download('myplug.hpi').with(
-          :url  => 'http://e.org/myplug.hpi',
-          :user => 'jenkins',
+         should contain_archive('/var/lib/jenkins/plugins/myplug.hpi').with(
+          :source  => 'http://e.org/myplug.hpi',
         )
         .that_requires('File[/var/lib/jenkins/plugins]')
       end
@@ -191,7 +172,7 @@ describe 'jenkins::plugin' do
         should contain_file('/var/lib/jenkins/plugins/foo.hpi.pinned').with(
           :owner => 'jenkins',
           :group => 'jenkins',
-        ).that_requires('Archive::Download[foo.hpi]')
+        ).that_requires('Archive[/var/lib/jenkins/plugins/foo.hpi]')
       end
     end
 
@@ -202,23 +183,10 @@ describe 'jenkins::plugin' do
         should contain_file('/var/lib/jenkins/plugins/foo.jpi.pinned').with(
           :owner => 'jenkins',
           :group => 'jenkins',
-        ).that_requires('Archive::Download[foo.jpi]')
+        ).that_requires('Archive[/var/lib/jenkins/plugins/foo.jpi]')
       end
     end
   end # pinned file extension name
-
-
-  context 'with an updated timeout' do
-    let(:timeout) { 1337 }
-    let(:title) { 'foo' }
-    let(:params) do
-      {
-        :timeout => timeout,
-      }
-    end
-
-    it { should contain_archive__download('foo.hpi').with_timeout(timeout) }
-  end
 
   describe 'deprecated params' do
     [

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -64,6 +64,22 @@ describe 'jenkins::plugin' do
     })}
   end
 
+  describe 'with proxy' do
+    let(:pre_condition) { [
+      'class jenkins {
+        $proxy_host = "proxy.company.com"
+        $proxy_port = 8080
+      }',
+      'include jenkins'
+    ]}
+
+    it do
+      should contain_archive__download('myplug.hpi').with(
+        :proxy_server => "proxy.company.com:8080",
+      )
+    end
+  end
+
   describe 'with a custom update center' do
     shared_examples 'execute the right fetch command' do
       it 'should retrieve the plugin' do

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -207,6 +207,19 @@ describe 'jenkins::plugin' do
     end
   end # pinned file extension name
 
+
+  context 'with an updated timeout' do
+    let(:timeout) { 1337 }
+    let(:title) { 'foo' }
+    let(:params) do
+      {
+        :timeout => timeout,
+      }
+    end
+
+    it { should contain_archive__download('foo.hpi').with_timeout(timeout) }
+  end
+
   describe 'deprecated params' do
     [
       'plugin_dir',


### PR DESCRIPTION
This replaces camptocamp/archive with puppet-community/puppet-archive.  There are other modules which use puppet-community/puppet-archive and this resolves the module namespace conflict.