### PR TITLE
Pass multiple --labels parameters

### DIFF
--- a/templates/jenkins-slave-defaults.erb
+++ b/templates/jenkins-slave-defaults.erb
@@ -70,9 +70,9 @@ if [ -n "$MASTER_URL" ]; then
   MASTER_URL_ARG="-master $MASTER_URL"
 fi
 
-if [ -n "$LABELS" ]; then
-  LABELS_ARG="-labels '$LABELS'"
-fi
+for LABEL in $LABELS; do
+  LABELS_ARG+="-labels $LABEL "
+done
 
 if [ -n "$FSROOT" ]; then
   FSROOT_ARG="-fsroot '$FSROOT'"


### PR DESCRIPTION
Pass multiple --labels parameters instead of passing one with the label
space separated. This seems to be more resilient.

Change-Id: I990f22cbb7201f9269cda8f0ece6196a2c04434d