### PR TITLE
travis does not need the :system_tests group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 before_install: gem install bundler -v '~> 1.6.0' --no-ri --no-rdoc
-bundler_args: "--without development plugins"
+bundler_args: "--without development system_tests"
 script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 rvm:
   - 1.9.3


### PR DESCRIPTION
Removing unnecessary gem deps should save some CI execution time.