### PR TITLE
Only run jenkins create-job, if the job not already exists

### DIFF
--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -73,6 +73,7 @@ define jenkins::job::present(
   exec { "jenkins create-job ${jobname}":
     command => "${cat_config} | ${create_job}",
     creates => [$config_path, "${job_dir}/builds"],
+    unless  => "${jenkins_cli} get-job \"${jobname}\"",
     require => File[$tmp_config_path],
   }
 


### PR DESCRIPTION
Have the job xml file in hiera, and the job configured in hiera this way:
```
jenkins::job_hash:
  update_puppet_environment:
    config: "%{hiera('update_puppet_environment.xml')}"
```

deploying jenkins the first time, it creates the job, running jenkins again, the command fails, because the job already exists. Because of this, add an unless parameter, that checks if the job already exists.

