### PR TITLE
Add ensure=>file to pinning file

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -103,6 +103,7 @@ define jenkins::plugin(
     }
 
     file { "${::jenkins::plugin_dir}/${plugin}.pinned":
+      ensure  => file,
       owner   => $::jenkins::user,
       group   => $::jenkins::group,
       require => Archive::Download[$plugin],

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -26,6 +26,7 @@ define jenkins::plugin(
   $digest_string   = '',
   $digest_type     = 'sha1',
   $timeout         = 120,
+  $pin             = false,
   # deprecated
   $plugin_dir      = undef,
   $username        = undef,
@@ -36,6 +37,7 @@ define jenkins::plugin(
 
   validate_bool($manage_config)
   validate_bool($enabled)
+  validate_bool($pin)
   # TODO: validate_str($update_url)
   validate_string($source)
   validate_string($digest_string)
@@ -102,8 +104,13 @@ define jenkins::plugin(
       notify  => Service['jenkins'],
     }
 
+    $pinned_ensure = $pin ? {
+      true    => file,
+      default => undef,
+    }
+
     file { "${::jenkins::plugin_dir}/${plugin}.pinned":
-      ensure  => file,
+      ensure  => $pinned_ensure,
       owner   => $::jenkins::user,
       group   => $::jenkins::group,
       require => Archive::Download[$plugin],

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -140,7 +140,7 @@ describe 'jenkins::plugin' do
   describe 'source' do
     shared_examples 'should download from $source url' do
       it 'should download from $source url' do
-         should contain_archive__download('myplug.hpi').with(
+        should contain_archive__download('myplug.hpi').with(
           :url  => 'http://e.org/myplug.hpi',
           :user => 'jenkins',
         )
@@ -203,6 +203,26 @@ describe 'jenkins::plugin' do
           :owner => 'jenkins',
           :group => 'jenkins',
         ).that_requires('Archive::Download[foo.jpi]')
+      end
+    end
+
+    describe 'pin parameter' do
+      context 'with pin => true' do
+        let(:params) {{ :pin => true } }
+        it do
+          should contain_file('/var/lib/jenkins/plugins/foo.hpi.pinned').with_ensure('file')
+        end
+      end
+      context 'with pin => false' do
+        let(:params) {{ :pin => false } }
+        it do
+          should contain_file('/var/lib/jenkins/plugins/foo.hpi.pinned').without_ensure
+        end
+      end
+      context 'with default pin param' do
+        it do
+          should contain_file('/var/lib/jenkins/plugins/foo.hpi.pinned').without_ensure
+        end
       end
     end
   end # pinned file extension name


### PR DESCRIPTION
Hi

This fix for https://github.com/jenkinsci/puppet-jenkins/issues/465 actually seems *too* simple.  It works for me, but I suspect I'm missing something! :)
But without an 'ensure' property, what did the file resource actually do?  Chown files if they happened to exist?

Kind Regards,
Alex