### PR TITLE
autorequire cli_jar from all PX::J::Type::Cli based types

### DIFF
--- a/lib/puppet_x/jenkins/type/cli.rb
+++ b/lib/puppet_x/jenkins/type/cli.rb
@@ -17,7 +17,7 @@ module PuppetX::Jenkins::Type::Cli
       config = PuppetX::Jenkins::Config.new(catalog)
 
       autos = []
-      %w( ssh_private_key puppet_helper ).each do |param|
+      %w( ssh_private_key puppet_helper cli_jar ).each do |param|
         value = config[param.to_sym]
         autos << value unless value.nil?
       end

--- a/spec/unit/puppet_x/spec_jenkins_types.rb
+++ b/spec/unit/puppet_x/spec_jenkins_types.rb
@@ -280,6 +280,73 @@ shared_examples 'autorequires cli resources' do
     expect(req[1].source).to eq helper_resource
     expect(req[1].target).to eq resource
   end
+
+  it "should autorequire cli_jar file from catalog" do
+    helper_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/catalog',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    jenkins = Puppet::Type.type(:component).new(
+      :name    => 'jenkins::cli::config',
+      :cli_jar => '/dne/catalog',
+    )
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource helper_resource
+    catalog.add_resource resource
+    catalog.add_resource jenkins
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq helper_resource
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire cli_jar file from fact" do
+    helper_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/fact',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    Facter.add(:jenkins_cli_jar) { setcode { '/dne/fact' } }
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource helper_resource
+    catalog.add_resource resource
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq helper_resource
+    expect(req[0].target).to eq resource
+  end
+
+  it "should autorequire cli_jar file from catalog instead of fact" do
+    helper_resource = Puppet::Type.type(:file).new(
+      :path => '/dne/catalog',
+    )
+    resource = described_class.new(
+      :name => 'test',
+    )
+    jenkins = Puppet::Type.type(:component).new(
+      :name    => 'jenkins::cli::config',
+      :cli_jar => '/dne/catalog',
+    )
+    Facter.add(:jenkins_cli_jar) { setcode { '/dne/fact' } }
+
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource helper_resource
+    catalog.add_resource resource
+    catalog.add_resource jenkins
+    req = resource.autorequire
+
+    expect(req.size).to eq 1
+    expect(req[0].source).to eq helper_resource
+    expect(req[0].target).to eq resource
+  end
+
 end # when autorequiring resources
 
 shared_examples 'autorequires all jenkins_user resources' do


### PR DESCRIPTION
Resolves this ordering error where the type attempts to run before the
CLI jar resource has been converted.

    ==> master: Error: Could not prefetch jenkins_security_realm provider
    'cli': Execution of '/bin/java -jar /usr/lib/jenkins/jenkins-cli.jar -s
    http://localhost:8080 groovy /usr/lib/jenkins/puppet_helper.groovy
    get_security_realm' returned 1: Error: Unable to access jarfile
    /usr/lib/jenkins/jenkins-cli.jar