### PR TITLE
enable install of cli_helper when jenkins::cli => true

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ puppet module install rtyler/jenkins
 ```
 Then the service should be running at [http://hostname.example.com:8080/](http://hostname.example.com:8080/).
 
-### Jenkin's options
+### Jenkins' options
 
 #### Master Executor Threads
 
@@ -145,9 +145,9 @@ parameters will have no effect on the plugin retrieval URL.
 Dependencies are not automatically installed. You need to manually determine the plugin dependencies and include those as well. The Jenkins wiki is a good place to do this. For example: The Git plugin page is at https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin.
 
 ### Slaves
-You can automatically add slaves to jenkins, and have them auto register themselves.  Most options are actually optional, as nodes will autodiscover the master, and connect.
+You can automatically add slaves to jenkins, and have them auto register themselves.  Most options are actually optional, as nodes will auto-discover the master, and connect.
 
-Full documention for the slave code is in jenkins::slave.
+Full documentation for the slave code is in jenkins::slave.
 
 It requires the swarm plugin on the master & the class jenkins::slave on the slaves, as below:
 
@@ -173,7 +173,7 @@ The dependencies for this module currently are:
 * [stdlib module](http://forge.puppetlabs.com/puppetlabs/stdlib)
 * [apt module](http://forge.puppetlabs.com/puppetlabs/apt) (for Debian/Ubuntu users)
 * [java module](http://github.com/puppetlabs/puppetlabs-java)
-* [zypprepo](https://forge.puppetlabs.com/darin/zypprepo) (for Suse users)
+* [zypprepo](https://forge.puppetlabs.com/darin/zypprepo) (for SUSE users)
 * [staging module](https://forge.puppetlabs.com/nanliu/staging)
 * [archive module](https://forge.puppetlabs.com/camptocamp/archive)
 
@@ -207,7 +207,7 @@ This module includes a groovy-based helper script that uses the
 interact with the Jenkins API. Users, Credentials, and security model
 configuration are all driven through this script.
 
-When an API-based resource is defined, the Jenkins CLI is installed and run
+When an API-based resource is defined, the Jenkins' CLI is installed and run
 against the local system (127.0.0.1). Jenkins is assumed to be listening on
 port 8080, but the module is smart enough to notice if you've configured an
 alternate port using jenkins::config_hash['HTTP_PORT'].

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ credentials.
 ### CLI Helper
 
 The CLI helper assumes unauthenticated access unless configured otherwise.
-You can configure jenkins::cli_helper to use an SSH key on the managed system
+You can configure `jenkins::cli_helper` to use an SSH key on the managed system
 by passing the keyfile path as a class parameter:
 ```puppet
   class {'jenkins':
@@ -231,6 +231,8 @@ by passing the keyfile path as a class parameter:
 ... or via hiera:
 
     jenkins::cli_ssh_keyfile: "/path/to/id_rsa"
+
+__Direct including of the `jenkins::cli_helper` class into the manifest is deprecated.__
 
 There's an open bug in Jenkins (JENKINS-22346) that causes authentication to
 fail when a key is used but authentication is disabled. Until the bug is fixed,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,7 +137,7 @@
 #   - Jenkins requires a JRE
 #
 #
-# cli = false (default)
+# cli = true (default)
 #   - force installation of the jenkins CLI jar to $libdir/cli/jenkins-cli.jar
 #   - the cli is automatically installed when needed by components that use it,
 #     such as the user and credentials types, and the security class
@@ -195,7 +195,7 @@ class jenkins(
   $proxy_host         = undef,
   $proxy_port         = undef,
   $no_proxy_list      = undef,
-  $cli                = undef,
+  $cli                = true,
   $cli_ssh_keyfile    = undef,
   $cli_tries          = $jenkins::params::cli_tries,
   $cli_try_sleep      = $jenkins::params::cli_try_sleep,
@@ -285,6 +285,7 @@ class jenkins(
 
   if $cli {
     include jenkins::cli
+    include jenkins::cli_helper
   }
 
   if $executors {

--- a/spec/classes/jenkins_cli_spec.rb
+++ b/spec/classes/jenkins_cli_spec.rb
@@ -5,7 +5,9 @@ describe 'jenkins', :type => :class do
 
   context 'cli' do
     context 'default' do
-      it { should_not contain_class('jenkins::cli') }
+      it { should contain_class('jenkins').with(:cli => true) }
+      it { should contain_class('jenkins::cli') }
+      it { should contain_class('jenkins::cli_helper') }
     end
 
     context '$cli => true' do
@@ -32,6 +34,13 @@ describe 'jenkins', :type => :class do
           end
         end
       end
+    end
+
+    context '$cli => false' do
+      let(:params) {{ :cli => false }}
+
+      it { should_not contain_class('jenkins::cli') }
+      it { should_not contain_class('jenkins::cli_helper') }
     end
   end
 end

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -133,14 +133,12 @@ describe 'jenkins', :type => :module do
 
     describe 'executors =>' do
       context 'undef' do
-        it { should_not contain_class('jenkins::cli_helper') }
         it { should_not contain_jenkins__cli__exec('set_num_executors') }
       end
 
       context '42' do
         let(:params) {{ :executors => 42 }}
 
-        it { should contain_class('jenkins::cli_helper') }
         it do
           should contain_jenkins__cli__exec('set_num_executors').with(
             :command => ['set_num_executors', 42],
@@ -162,7 +160,6 @@ describe 'jenkins', :type => :module do
 
     describe 'slaveagentport =>' do
       context 'undef' do
-        it { should_not contain_class('jenkins::cli_helper') }
         it { should_not contain_jenkins__cli__exec('set_slaveagent_port') }
       end
 
@@ -170,7 +167,6 @@ describe 'jenkins', :type => :module do
         let(:port) { 7777 }
         let(:params) {{ :slaveagentport => port }}
 
-        it { should contain_class('jenkins::cli_helper') }
         it do
           should contain_jenkins__cli__exec('set_slaveagent_port').with(
             :command => ['set_slaveagent_port', port],


### PR DESCRIPTION
+ make true the default value of the `jenkins` class `cli` param

This modules uses the cli jar + groovy helper for many of its'
management functions and is currently relying on these to be
automatically included by dependent resources.  For most use cases of
this module, the cli jar + groovy helper are automatically installed
regardless of the value of the `cli` param.  However, this does not
work for the experimental native types which are dependent on the cli
jar and groovy helper.