### PR TITLE
Remove extra include

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -32,7 +32,6 @@ define jenkins::plugin(
   $group           = undef,
   $create_user     = undef,
 ) {
-  include ::jenkins
 
   validate_bool($manage_config)
   validate_bool($enabled)


### PR DESCRIPTION
I believe this extra check is a bad idea ... It makes the module rely on quite a specific puppet behaviour (and arguably a bad design).

Namely in Puppet this works

```
class { 'jenkins':}
include jenkins
```
but this won't:
``` 
include jenkins
class { 'jenkins':}
```
I would love to see the following include removed because I don't think it is terribly relevant to add such a check there.
That said, my main motivation is the fact that [language-puppet](https://github.com/bartavelle/language-puppet) doesn't currently support such idiom.
