### PR TITLE
Add support for prefix configuration in the CLI config class.

### DIFF
--- a/NATIVE_TYPES_AND_PROVIDERS.md
+++ b/NATIVE_TYPES_AND_PROVIDERS.md
@@ -31,7 +31,7 @@ However, the version included in this module has provides some additional
 setup.  The parameters used to override default values are:
 
 * `cli_jar`
-* `port`
+* `url`
 * `ssh_private_key`
 * `puppet_helper`
 * `cli_tries`
@@ -48,11 +48,19 @@ class { 'jenkins::cli::config':
 }
 ```
 
+An example of setting an alternative port number and an addition of a prefix.
+
+```
+class { 'jenkins::cli::config':
+  ssh_private_key => 'http://localhost:9999/awesome-jenkins',
+}
+```
+
 These values may also be set via facts with the same name after the prefix
 `jenkins_`.  Class parameters have precedence over fact values.
 
 * `jenkins_cli_jar`
-* `jenkins_port`
+* `jenkins_url`
 * `jenkins_ssh_private_key`
 * `jenkins_puppet_helper`
 * `jenkins_cli_tries`

--- a/NATIVE_TYPES_AND_PROVIDERS.md
+++ b/NATIVE_TYPES_AND_PROVIDERS.md
@@ -52,7 +52,7 @@ An example of setting an alternative port number and an addition of a prefix.
 
 ```
 class { 'jenkins::cli::config':
-  ssh_private_key => 'http://localhost:9999/awesome-jenkins',
+  url => 'http://localhost:9999/awesome-jenkins',
 }
 ```
 

--- a/lib/puppet_x/jenkins/config.rb
+++ b/lib/puppet_x/jenkins/config.rb
@@ -11,7 +11,7 @@ class PuppetX::Jenkins::Config
 
   DEFAULTS = {
     :cli_jar         => '/usr/lib/jenkins/jenkins-cli.jar',
-    :port            => 8080,
+    :url             => 'http://localhost:8080',
     :ssh_private_key => nil,
     :puppet_helper   => '/usr/lib/jenkins/puppet_helper.groovy',
     :cli_tries       => 30,

--- a/lib/puppet_x/jenkins/provider/cli.rb
+++ b/lib/puppet_x/jenkins/provider/cli.rb
@@ -143,7 +143,7 @@ class PuppetX::Jenkins::Provider::Cli < Puppet::Provider
 
     config = PuppetX::Jenkins::Config.new(catalog)
     cli_jar         = config[:cli_jar]
-    port            = config[:port]
+    url             = config[:url]
     ssh_private_key = config[:ssh_private_key]
     cli_tries       = config[:cli_tries]
     cli_try_sleep   = config[:cli_try_sleep]
@@ -151,7 +151,7 @@ class PuppetX::Jenkins::Provider::Cli < Puppet::Provider
     base_cmd = [
       command(:java),
       '-jar', cli_jar,
-      '-s', "http://localhost:#{port}",
+      '-s', url,
     ]
 
     cli_cmd = base_cmd + [command]

--- a/manifests/cli/config.pp
+++ b/manifests/cli/config.pp
@@ -8,7 +8,7 @@
 # resource face.  No defaults should be set in this classes definition.
 class jenkins::cli::config(
   $cli_jar                 = undef,
-  $port                    = undef,
+  $url                     = undef,
   $ssh_private_key         = undef,
   $puppet_helper           = undef,
   $cli_tries               = undef,
@@ -16,7 +16,7 @@ class jenkins::cli::config(
   $ssh_private_key_content = undef,
 ) {
   if $cli_jar { validate_absolute_path($cli_jar) }
-  if $port { validate_integer($port) }
+  validate_string($url)
   if $ssh_private_key { validate_absolute_path($ssh_private_key) }
   if $puppet_helper { validate_absolute_path($puppet_helper) }
   if $cli_tries { validate_integer($cli_tries) }

--- a/spec/classes/cli/config_spec.rb
+++ b/spec/classes/cli/config_spec.rb
@@ -78,8 +78,11 @@ describe 'jenkins::cli::config', :type => :class do
       it_behaves_like 'validate_absolute_path', :cli_jar
     end
 
-    context 'port' do
-      it_behaves_like 'validate_integer', :port
+    # context 'port' do
+    #   it_behaves_like 'validate_integer', :port
+    # end
+    context 'url' do
+      it_behaves_like 'validate_string', :url
     end
 
     context 'ssh_private_key' do

--- a/spec/unit/puppet_x/jenkins/config_spec.rb
+++ b/spec/unit/puppet_x/jenkins/config_spec.rb
@@ -5,7 +5,7 @@ require 'puppet_x/jenkins/config'
 describe PuppetX::Jenkins::Config do
   DEFAULTS = {
     :cli_jar         => '/usr/lib/jenkins/jenkins-cli.jar',
-    :port            => 8080,
+    :url             => 'http://localhost:8080',
     :ssh_private_key => nil,
     :puppet_helper   => '/usr/lib/jenkins/puppet_helper.groovy',
     :cli_tries       => 30,
@@ -15,7 +15,7 @@ describe PuppetX::Jenkins::Config do
   shared_context 'facts' do
     before do
       Facter.add(:jenkins_cli_jar) { setcode { 'fact.jar' } }
-      Facter.add(:jenkins_port) { setcode { 11 } }
+      Facter.add(:jenkins_url) { setcode { 'http://localhost:11' } }
       Facter.add(:jenkins_ssh_private_key) { setcode { 'fact.id_rsa' } }
       Facter.add(:jenkins_puppet_helper) { setcode { 'fact.groovy' } }
       Facter.add(:jenkins_cli_tries) { setcode { 22 } }
@@ -121,7 +121,7 @@ describe PuppetX::Jenkins::Config do
             jenkins = Puppet::Type.type(:component).new(
               :name            => 'jenkins::cli::config',
               :cli_jar         => 'cat.jar',
-              :port            => 111,
+              :url             => 'http://localhost:111',
               :ssh_private_key => 'cat.id_rsa',
               :puppet_helper   => 'cat.groovy',
               :cli_tries       => 222,

--- a/spec/unit/puppet_x/jenkins/provider/cli_spec.rb
+++ b/spec/unit/puppet_x/jenkins/provider/cli_spec.rb
@@ -22,7 +22,7 @@ describe PuppetX::Jenkins::Provider::Cli do
   shared_context 'facts' do
     before do
       Facter.add(:jenkins_cli_jar) { setcode { 'fact.jar' } }
-      Facter.add(:jenkins_port) { setcode { 11 } }
+      Facter.add(:jenkins_url) { setcode { 'http://localhost:11' } }
       Facter.add(:jenkins_ssh_private_key) { setcode { 'fact.id_rsa' } }
       Facter.add(:jenkins_puppet_helper) { setcode { 'fact.groovy' } }
       Facter.add(:jenkins_cli_tries) { setcode { 22 } }
@@ -399,7 +399,7 @@ describe PuppetX::Jenkins::Provider::Cli do
           jenkins = Puppet::Type.type(:component).new(
             :name            => 'jenkins::cli::config',
             :cli_jar         => 'cat.jar',
-            :port            => 111,
+            :url             => 'http://localhost:111',
             :ssh_private_key => 'cat.id_rsa',
             :cli_tries       => 222,
             :cli_try_sleep   => 333,


### PR DESCRIPTION
This change adds a prefix configration to the jenkins::cli::config class. The prefix is then used in the CLI command to connect to a Jenkins servers which has a prefix configured (in the config_hash). 