### PR TITLE
Add folder support to puppet_helper

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -887,10 +887,15 @@ class Actions {
    * Print the job's state as either "true" or "false"
   */
   void job_enabled(String name) {
-    def disabled = Jenkins.getInstance().getJob(name).isDisabled()
-    out.println(!disabled)
-  }
-} // class Actions
+    try {
+      def disabled = Jenkins.getInstance().getJob(name).isDisabled()
+      out.println(!disabled)
+    }
+    catch (MissingMethodException me) {
+      out.println("Found resource is not a job, skipping.")
+    }
+   }
+  } // class Actions
 
 ///////////////////////////////////////////////////////////////////////////////
 // CLI Argument Processing


### PR DESCRIPTION
Use case:
We use the jenkins_job to create a "seed" job which calls some groovy scripts
 which are responsible for the actual build jobs creation.
 [Job DSL plugin](https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin).
 Part of this DSL are folders, supported by the Cloudbees folder plugin.

Folders however are currently not supported by `puppet_helper.groovy`. When
folders are added the following exception is thrown

```bash
Error: Failed to apply catalog: Execution of '/bin/java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 -i /kvk/.ssh/id_rsa groovy /usr/lib/jenkins/puppet_helper.groovy job_enabled monitoring' r
eturned 255: Unexpected exception occurred while performing groovy command!
groovy.lang.MissingMethodException: No signature of method: com.cloudbees.hudson.plugins.folder.Folder.isDisabled() is applicable for argument types: () values: []
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:55)
...
```

This PR surrounds the `def disabled = Jenkins.getInstance().getJob(name)
.isDisabled()`
with a catch block that prevents the puppet run from failing whenever a job is
found that actually is a folder.
