### PR TITLE
Conditionally include apt class

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -7,7 +7,7 @@ class jenkins::repo::debian
   }
 
   include stdlib
-  include apt
+  if ! defined("apt") { include apt }
 
   if $::jenkins::lts  {
     apt::source { 'jenkins':


### PR DESCRIPTION
Because some other Puppet module might have done this earlier.