### PR TITLE
fix plugin install logic matching

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -63,7 +63,7 @@ define jenkins::plugin(
       default => $update_url,
     }
     $base_url = "${plugins_host}/download/plugins/${name}/${version}/"
-    $search   = "${name} ${version}(,|$)"
+    $search   = "^${name} ${version}$"
   }
   else {
     $plugins_host = $update_url ? {
@@ -82,8 +82,12 @@ define jenkins::plugin(
 
   $plugin_ext = regsubst($download_url, '^.*\.(hpi|jpi)$', '\1')
   $plugin     = "${name}.${plugin_ext}"
+  $installed_plugins = $::jenkins_plugins ? {
+    undef   => [],
+    default => strip(split($::jenkins_plugins, ',')),
+  }
 
-  if (empty(grep([ $::jenkins_plugins ], $search))) {
+  if (empty(grep($installed_plugins, $search))) {
     if ($jenkins::proxy_host) {
       $proxy_server = "${jenkins::proxy_host}:${jenkins::proxy_port}"
     } else {

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -49,6 +49,40 @@ describe 'jenkins::plugin' do
     it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
   end
 
+  describe 'with name and version' do
+    describe 'where name & version are a substring of another plugin' do
+      let(:params) { { :version => '1.2.3' } }
+      before { facts[:jenkins_plugins] = 'fooplug 1.4.5, bar-myplug 1.2.3' }
+
+      it { should contain_archive__download('myplug.hpi') }
+      it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+    end
+
+    describe 'where name & version are a substring of another plugin' do
+      let(:params) { { :version => '1.2.3' } }
+      before { facts[:jenkins_plugins] = 'fooplug 1.4.5, bar-myplug 1.2.3.4' }
+
+      it { should contain_archive__download('myplug.hpi') }
+      it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+    end
+
+    describe 'where version is a substring of the already installed plugin' do
+      let(:params) { { :version => '1.2.3' } }
+      before { facts[:jenkins_plugins] = 'fooplug 1.4.5, myplug 1.2.3.4' }
+
+      it { should contain_archive__download('myplug.hpi') }
+      it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+    end
+
+    describe 'and no plugins are installed (should not actually happen)' do
+      let(:params) { { :version => '1.2.3' } }
+      before { facts[:jenkins_plugins] = '' }
+
+      it { should contain_archive__download('myplug.hpi') }
+      it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+    end
+  end # 'with name and version'
+
   describe 'with enabled is false' do
     let(:params) { { :enabled => false } }
 


### PR DESCRIPTION
It was possible for a plugin to fail to be installed if it's name and
version matched as a substring of an already installed plugin. Which
means that a test for `credentials 1.12` could potentially match on an
incorrect plugin name such as `ssh-credentials 1.12`.

resolves #513