### PR TITLE
use puppet/archive for all file downloads

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,6 @@ fixtures:
     java: "https://github.com/puppetlabs/puppetlabs-java"
     zypprepo: "https://github.com/deadpoint/puppet-zypprepo.git"
     staging: "https://github.com/nanliu/puppet-staging"
-    archive: "https://github.com/puppet-community/puppet-archive.git"
+    archive: "https://github.com/voxpupuli/puppet-archive.git"
   symlinks:
     "jenkins": "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,6 @@ fixtures:
       ref: "4.6.0"
     java: "https://github.com/puppetlabs/puppetlabs-java"
     zypprepo: "https://github.com/deadpoint/puppet-zypprepo.git"
-    staging: "https://github.com/nanliu/puppet-staging"
     archive: "https://github.com/voxpupuli/puppet-archive.git"
   symlinks:
     "jenkins": "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,6 @@ fixtures:
     java: "https://github.com/puppetlabs/puppetlabs-java"
     zypprepo: "https://github.com/deadpoint/puppet-zypprepo.git"
     staging: "https://github.com/nanliu/puppet-staging"
-    archive: "https://github.com/camptocamp/puppet-archive"
+    archive: "https://github.com/puppet-community/puppet-archive.git"
   symlinks:
     "jenkins": "#{source_dir}"

--- a/manifests/direct_download.pp
+++ b/manifests/direct_download.pp
@@ -26,9 +26,9 @@ class jenkins::direct_download {
 
   if $::jenkins::version != 'absent' {
     # make download optional if we are removing...
-    staging::file { $package_file:
+    archive { $package_file:
       source => $jenkins::direct_download,
-      target => $local_file,
+      path   => $local_file,
       before => Package[$::jenkins::package_name],
     }
   }

--- a/manifests/direct_download.pp
+++ b/manifests/direct_download.pp
@@ -27,9 +27,12 @@ class jenkins::direct_download {
   if $::jenkins::version != 'absent' {
     # make download optional if we are removing...
     archive { $package_file:
-      source => $jenkins::direct_download,
-      path   => $local_file,
-      before => Package[$::jenkins::package_name],
+      source       => $jenkins::direct_download,
+      path         => $local_file,
+      proxy_server => $::jenkins::proxy_server,
+      cleanup      => false,
+      extract      => false,
+      before       => Package[$::jenkins::package_name],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -276,7 +276,13 @@ class jenkins(
       require => Package['jenkins'],
       notify  => Service['jenkins']
     }
+
+    # param format needed by puppet/archive
+    $proxy_server = "http://${jenkins::proxy_host}:${jenkins::proxy_port}"
+  } else {
+    $proxy_server = undef
   }
+
 
   include jenkins::service
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -118,7 +118,7 @@ define jenkins::plugin(
       ensure  => $pinned_ensure,
       owner   => $::jenkins::user,
       group   => $::jenkins::group,
-      require => Archive::Download[$plugin],
+      require => Archive["${::jenkins::plugin_dir}/${plugin}"],
     }
 
     if $digest_string == '' {
@@ -127,20 +127,13 @@ define jenkins::plugin(
       $checksum = true
     }
 
-    archive::download { $plugin:
-      url              => $download_url,
-      src_target       => $::jenkins::plugin_dir,
-      allow_insecure   => true,
-      follow_redirects => true,
-      verbose          => false,
-      checksum         => $checksum,
-      digest_string    => $digest_string,
-      digest_type      => $digest_type,
-      user             => $::jenkins::user,
-      proxy_server     => $proxy_server,
-      notify           => Service['jenkins'],
-      require          => File[$::jenkins::plugin_dir],
-      timeout          => $timeout,
+    archive { "${::jenkins::plugin_dir}/${plugin}":
+      source          => $download_url,
+      checksum_verify => $checksum,
+      checksum        => $digest_string,
+      checksum_type   => $digest_type,
+      notify          => Service['jenkins'],
+      require         => File[$::jenkins::plugin_dir],
     }
 
     file { "${::jenkins::plugin_dir}/${plugin}" :

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -23,10 +23,11 @@ define jenkins::plugin(
   $update_url      = undef,
   $enabled         = true,
   $source          = undef,
-  $digest_string   = '',
+  $digest_string   = undef,
   $digest_type     = 'sha1',
-  $timeout         = 120,
   $pin             = false,
+  # no worky
+  $timeout         = undef,
   # deprecated
   $plugin_dir      = undef,
   $username        = undef,
@@ -35,12 +36,18 @@ define jenkins::plugin(
 ) {
   validate_string($version)
   validate_bool($manage_config)
+  validate_string($config_filename)
+  validate_string($config_content)
+  validate_string($update_url)
   validate_bool($enabled)
-  validate_bool($pin)
-  # TODO: validate_str($update_url)
   validate_string($source)
   validate_string($digest_string)
   validate_string($digest_type)
+  validate_bool($pin)
+
+  if $timeout {
+    warning('jenkins::plugin::timeout presently has effect')
+  }
 
   if $plugin_dir {
     warning('jenkins::plugin::plugin_dir is deprecated and has no effect -- see jenkins::localstatedir')
@@ -124,12 +131,12 @@ define jenkins::plugin(
       notify  => Service['jenkins'],
     }
 
-    if $digest_string == '' {
-      $checksum_verify = false
-      $checksum = undef
-    } else {
+    if $digest_string {
       $checksum_verify = true
       $checksum = $digest_string
+    } else {
+      $checksum_verify = false
+      $checksum = undef
     }
 
     archive { $plugin:

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -132,6 +132,7 @@ define jenkins::plugin(
       checksum_verify => $checksum,
       checksum        => $digest_string,
       checksum_type   => $digest_type,
+      proxy_server    => $proxy_server,
       notify          => Service['jenkins'],
       require         => File[$::jenkins::plugin_dir],
     }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -89,7 +89,9 @@ define jenkins::plugin(
 
   if (empty(grep($installed_plugins, $search))) {
     if ($jenkins::proxy_host) {
-      $proxy_server = "${jenkins::proxy_host}:${jenkins::proxy_port}"
+      # archive expects protocol in proxy_server, but jenkins proxy.xml expects no protocol
+      # assume http
+      $proxy_server = "http://${jenkins::proxy_host}:${jenkins::proxy_port}"
     } else {
       $proxy_server = undef
     }
@@ -122,15 +124,17 @@ define jenkins::plugin(
     }
 
     if $digest_string == '' {
-      $checksum = false
+      $checksum_verify = false
+      $checksum = undef
     } else {
-      $checksum = true
+      $checksum_verify = true
+      $checksum = $digest_string
     }
 
     archive { "${::jenkins::plugin_dir}/${plugin}":
       source          => $download_url,
-      checksum_verify => $checksum,
-      checksum        => $digest_string,
+      checksum_verify => $checksum_verify,
+      checksum        => $checksum,
       checksum_type   => $digest_type,
       proxy_server    => $proxy_server,
       notify          => Service['jenkins'],
@@ -138,7 +142,7 @@ define jenkins::plugin(
     }
 
     file { "${::jenkins::plugin_dir}/${plugin}" :
-      require => Archive::Download[$plugin],
+      require => Archive["${::jenkins::plugin_dir}/${plugin}"],
       owner   => $::jenkins::user,
       group   => $::jenkins::group,
       mode    => '0644',

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -107,7 +107,7 @@ define jenkins::plugin(
       owner   => $::jenkins::user,
       group   => $::jenkins::group,
       mode    => '0644',
-      require => File["${::jenkins::plugin_dir}/${plugin}"],
+      require => Archive[$plugin],
       notify  => Service['jenkins'],
     }
 
@@ -120,7 +120,8 @@ define jenkins::plugin(
       ensure  => $pinned_ensure,
       owner   => $::jenkins::user,
       group   => $::jenkins::group,
-      require => Archive["${::jenkins::plugin_dir}/${plugin}"],
+      require => Archive[$plugin],
+      notify  => Service['jenkins'],
     }
 
     if $digest_string == '' {
@@ -131,21 +132,25 @@ define jenkins::plugin(
       $checksum = $digest_string
     }
 
-    archive { "${::jenkins::plugin_dir}/${plugin}":
+    archive { $plugin:
       source          => $download_url,
+      path            => "${::jenkins::plugin_dir}/${plugin}",
       checksum_verify => $checksum_verify,
       checksum        => $checksum,
       checksum_type   => $digest_type,
-      proxy_server    => $proxy_server,
-      notify          => Service['jenkins'],
+      proxy_server    => $::jenkins::proxy_server,
+      cleanup         => false,
+      extract         => false,
       require         => File[$::jenkins::plugin_dir],
+      notify          => Service['jenkins'],
     }
 
     file { "${::jenkins::plugin_dir}/${plugin}" :
-      require => Archive["${::jenkins::plugin_dir}/${plugin}"],
       owner   => $::jenkins::user,
       group   => $::jenkins::group,
       mode    => '0644',
+      require => Archive[$plugin],
+      before  => Service['jenkins'],
     }
   }
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -95,14 +95,6 @@ define jenkins::plugin(
   }
 
   if (empty(grep($installed_plugins, $search))) {
-    if ($jenkins::proxy_host) {
-      # archive expects protocol in proxy_server, but jenkins proxy.xml expects no protocol
-      # assume http
-      $proxy_server = "http://${jenkins::proxy_host}:${jenkins::proxy_port}"
-    } else {
-      $proxy_server = undef
-    }
-
     $enabled_ensure = $enabled ? {
       false   => present,
       default => absent,

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -253,14 +253,12 @@ class jenkins::slave (
   }
 
   if ($manage_client_jar) {
-    exec { 'get_swarm_client':
-      command => $fetch_command,
-      path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-      user    => $slave_user,
-      creates => "${slave_home}/${client_jar}",
-      cwd     => $slave_home,
-      #refreshonly  => true,
-    ## needs to be fixed if you create another version..
+    archive { 'get_swarm_client':
+      source       => "${client_url}/${client_jar}",
+      path         => "${slave_home}/${client_jar}",
+      proxy_server => $::jenkins::proxy_server,
+      cleanup      => false,
+      extract      => false,
     }
   }
 

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -170,7 +170,6 @@ class jenkins::slave (
 
   case $::kernel {
     'Linux': {
-      $fetch_command  = "wget -O ${slave_home}/${client_jar} ${client_url}/${client_jar}"
       $service_name   = 'jenkins-slave'
       $defaults_user  = 'root'
       $defaults_group = 'root'
@@ -186,7 +185,6 @@ class jenkins::slave (
       }
     }
     'Darwin': {
-      $fetch_command    = "curl -O ${client_url}/${client_jar}"
       $service_name     = 'org.jenkins-ci.slave.jnlp'
       $defaults_user    = 'jenkins'
       $defaults_group   = 'wheel'
@@ -259,6 +257,7 @@ class jenkins::slave (
       proxy_server => $::jenkins::proxy_server,
       cleanup      => false,
       extract      => false,
+      require      => User['jenkins-slave_user'],
     }
   }
 
@@ -271,12 +270,12 @@ class jenkins::slave (
   }
 
   if ($manage_client_jar) {
-    Exec['get_swarm_client'] ->
-    Service['jenkins-slave']
+    Archive['get_swarm_client'] ->
+      Service['jenkins-slave']
   }
 
   if $install_java and ($::osfamily != 'Darwin') {
     Class['java'] ->
-    Service['jenkins-slave']
+      Service['jenkins-slave']
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,6 @@
     { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.3 < 3.0.0" },
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
-    { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" },
     { "name": "puppet/archive", "version_requirement": ">= 0.4.8" }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,6 @@
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" },
-    { "name": "camptocamp/archive", "version_requirement": ">= 0.8.0" }
+    { "name": "puppetcommunity/puppet-archive", "version_requirement": ">= 0.3.0" }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,6 @@
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "nanliu/staging", "version_requirement": ">= 1.0.0 < 2.0.0" },
-    { "name": "puppetcommunity/puppet-archive", "version_requirement": ">= 0.3.0" }
+    { "name": "puppet/archive", "version_requirement": ">= 0.4.8" }
   ]
 }

--- a/spec/classes/jenkins_direct_download_spec.rb
+++ b/spec/classes/jenkins_direct_download_spec.rb
@@ -30,10 +30,12 @@ describe 'jenkins', :type => :module do
 
     context 'staging resource created' do
       it do
-        should contain_archive('jenkins.rpm').with({
-          :source => 'http://local.space/jenkins.rpm',
-          :path   => '/var/cache/jenkins_pkgs/jenkins.rpm',
-        })
+        should contain_archive('jenkins.rpm').with(
+          :source  => 'http://local.space/jenkins.rpm',
+          :path    => '/var/cache/jenkins_pkgs/jenkins.rpm',
+          :cleanup => false,
+          :extract => false,
+        ).that_comes_before("Package[jenkins]")
       end
     end
 

--- a/spec/classes/jenkins_direct_download_spec.rb
+++ b/spec/classes/jenkins_direct_download_spec.rb
@@ -29,7 +29,12 @@ describe 'jenkins', :type => :module do
     end
 
     context 'staging resource created' do
-      it { should contain_staging__file('jenkins.rpm').with_source('http://local.space/jenkins.rpm') }
+      it do
+        should contain_archive('jenkins.rpm').with({
+          :source => 'http://local.space/jenkins.rpm',
+          :path   => '/var/cache/jenkins_pkgs/jenkins.rpm',
+        })
+      end
     end
 
     context 'package removable' do

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -7,7 +7,7 @@ describe 'jenkins::slave' do
       should contain_archive('get_swarm_client').with(
         :cleanup => false,
         :extract => false,
-      )
+      ).that_requires('User[jenkins-slave_user]')
     end
     it { should contain_file(slave_service_file) }
     it { should contain_service('jenkins-slave').with(:enable => true, :ensure => 'running') }

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -3,7 +3,12 @@ require 'spec_helper'
 describe 'jenkins::slave' do
 
   shared_context 'a jenkins::slave catalog' do
-    it { should contain_exec('get_swarm_client') }
+    it do
+      should contain_archive('get_swarm_client').with(
+        :cleanup => false,
+        :extract => false,
+      )
+    end
     it { should contain_file(slave_service_file) }
     it { should contain_service('jenkins-slave').with(:enable => true, :ensure => 'running') }
     it { should contain_user('jenkins-slave_user').with_uid(nil) }

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -116,7 +116,7 @@ describe 'jenkins::plugin' do
 
     it do
       should contain_archive('myplug.hpi').with(
-        :proxy_server => "proxy.company.com:8080",
+        :proxy_server => "http://proxy.company.com:8080",
       )
     end
   end

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -10,41 +10,53 @@ describe 'jenkins::plugin' do
       :operatingsystemmajrelease => '6',
     }
   end
+  let(:pdir) { '/var/lib/jenkins/plugins' }
 
   describe 'without version' do
     it do
-      should contain_archive('/var/lib/jenkins/plugins/myplug.hpi').with(
+      should contain_archive("#{title}.hpi").with(
         :source  =>  'https://updates.jenkins-ci.org/latest/myplug.hpi',
-      )
+        :path    => "#{pdir}/#{title}.hpi",
+        :cleanup => false,
+        :extract => false,
+      ).that_requires("File[#{pdir}]")
+       .that_notifies('Service[jenkins]')
     end
-    it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+    it do
+      should contain_file("#{pdir}/#{title}.hpi").with(
+        :owner => 'jenkins',
+        :group => 'jenkins',
+        :mode  => '0644',
+      ).that_requires("Archive[#{title}.hpi]")
+       .that_comes_before('Service[jenkins]')
+    end
   end
 
   describe 'with version' do
     let(:params) { { :version => '1.2.3' } }
 
     it do
-      should contain_archive('/var/lib/jenkins/plugins/myplug.hpi').with(
+      should contain_archive('myplug.hpi').with(
         :source  =>  'https://updates.jenkins-ci.org/download/plugins/myplug/1.2.3/myplug.hpi',
       )
     end
-    it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+    it { should contain_file("#{pdir}/myplug.hpi")}
   end
 
   describe 'with version and in middle of jenkins_plugins fact' do
     let(:params) { { :version => '1.2.3' } }
     before { facts[:jenkins_plugins] = 'myplug 1.2.3, fooplug 1.4.5' }
 
-    it { should_not contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
-    it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+    it { should_not contain_archive('myplug.hpi') }
+    it { should_not contain_file("#{pdir}/myplug.hpi")}
   end
 
   describe 'with version and at end of jenkins_plugins fact' do
     let(:params) { { :version => '1.2.3' } }
     before { facts[:jenkins_plugins] = 'fooplug 1.4.5, myplug 1.2.3' }
 
-    it { should_not contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
-    it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+    it { should_not contain_archive('myplug.hpi') }
+    it { should_not contain_file("#{pdir}/myplug.hpi")}
   end
 
   describe 'with name and version' do
@@ -52,7 +64,7 @@ describe 'jenkins::plugin' do
       let(:params) { { :version => '1.2.3' } }
       before { facts[:jenkins_plugins] = 'fooplug 1.4.5, bar-myplug 1.2.3' }
 
-      it { should contain_archive__download('myplug.hpi') }
+      it { should contain_archive('myplug.hpi') }
       it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
     end
 
@@ -60,7 +72,7 @@ describe 'jenkins::plugin' do
       let(:params) { { :version => '1.2.3' } }
       before { facts[:jenkins_plugins] = 'fooplug 1.4.5, bar-myplug 1.2.3.4' }
 
-      it { should contain_archive__download('myplug.hpi') }
+      it { should contain_archive('myplug.hpi') }
       it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
     end
 
@@ -68,7 +80,7 @@ describe 'jenkins::plugin' do
       let(:params) { { :version => '1.2.3' } }
       before { facts[:jenkins_plugins] = 'fooplug 1.4.5, myplug 1.2.3.4' }
 
-      it { should contain_archive__download('myplug.hpi') }
+      it { should contain_archive('myplug.hpi') }
       it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
     end
 
@@ -76,7 +88,7 @@ describe 'jenkins::plugin' do
       let(:params) { { :version => '1.2.3' } }
       before { facts[:jenkins_plugins] = '' }
 
-      it { should contain_archive__download('myplug.hpi') }
+      it { should contain_archive('myplug.hpi') }
       it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
     end
   end # 'with name and version'
@@ -84,34 +96,37 @@ describe 'jenkins::plugin' do
   describe 'with enabled is false' do
     let(:params) { { :enabled => false } }
 
-    it { should contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
-    it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
-    it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi.disabled').with({
-      :ensure => 'present',
-      :owner  => 'jenkins',
-      :group  => 'jenkins',
-    })}
+    it { should contain_archive('myplug.hpi') }
+    it { should contain_file("#{pdir}/myplug.hpi")}
+    it do
+      should contain_file("#{pdir}/myplug.hpi.disabled").with(
+        :ensure => 'present',
+        :owner  => 'jenkins',
+        :group  => 'jenkins',
+        :mode   => '0644',
+      ).that_requires("Archive[#{title}.hpi]")
+       .that_notifies('Service[jenkins]')
+    end
   end
 
   describe 'with enabled is true' do
     let(:params) { { :enabled => true } }
 
-    it { should contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
-    it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
-    it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi.disabled').with({
-      :ensure => 'absent',
-      :owner  => 'jenkins',
-      :group  => 'jenkins',
-    })}
+    it { should contain_archive('myplug.hpi') }
+    it { should contain_file("#{pdir}/myplug.hpi")}
+    it do
+      should contain_file("#{pdir}/myplug.hpi.disabled").with(
+        :ensure => 'absent',
+      )
+    end
   end
 
   describe 'with proxy' do
     let(:pre_condition) { [
-      'class jenkins {
-        $proxy_host = "proxy.company.com"
-        $proxy_port = 8080
+      'class { jenkins:
+        proxy_host => "proxy.company.com",
+        proxy_port => 8080,
       }',
-      'include jenkins'
     ]}
 
     it do
@@ -124,7 +139,7 @@ describe 'jenkins::plugin' do
   describe 'with a custom update center' do
     shared_examples 'execute the right fetch command' do
       it 'should retrieve the plugin' do
-        expect(subject).to contain_archive('/var/lib/jenkins/plugins/git.hpi').with({
+        expect(subject).to contain_archive('git.hpi').with({
           :source => "#{expected_url}",
         })
       end
@@ -179,10 +194,10 @@ describe 'jenkins::plugin' do
   describe 'source' do
     shared_examples 'should download from $source url' do
       it 'should download from $source url' do
-         should contain_archive('/var/lib/jenkins/plugins/myplug.hpi').with(
+         should contain_archive('myplug.hpi').with(
           :source  => 'http://e.org/myplug.hpi',
         )
-        .that_requires('File[/var/lib/jenkins/plugins]')
+        .that_requires("File[#{pdir}]")
       end
     end
 
@@ -226,40 +241,35 @@ describe 'jenkins::plugin' do
 
     context 'default params' do
       it do
-        should contain_file('/var/lib/jenkins/plugins/foo.hpi.pinned').with(
-          :owner => 'jenkins',
-          :group => 'jenkins',
-        ).that_requires('Archive[/var/lib/jenkins/plugins/foo.hpi]')
+        should contain_file("#{pdir}/foo.hpi.pinned").with(
+          :ensure => nil,
+          :owner  => 'jenkins',
+          :group  => 'jenkins',
+        ).that_requires("Archive[foo.hpi]")
+         .that_notifies('Service[jenkins]')
       end
     end
 
     context 'with source param' do
       let(:params) {{ :source => 'foo.jpi' }}
 
-      it do
-        should contain_file('/var/lib/jenkins/plugins/foo.jpi.pinned').with(
-          :owner => 'jenkins',
-          :group => 'jenkins',
-        ).that_requires('Archive[/var/lib/jenkins/plugins/foo.jpi]')
-      end
+      it { should contain_file("#{pdir}/foo.jpi.pinned").without_ensure }
     end
 
     describe 'pin parameter' do
       context 'with pin => true' do
         let(:params) {{ :pin => true } }
-        it do
-          should contain_file('/var/lib/jenkins/plugins/foo.hpi.pinned').with_ensure('file')
-        end
+        it { should contain_file("#{pdir}/foo.hpi.pinned").with_ensure('file') }
       end
       context 'with pin => false' do
         let(:params) {{ :pin => false } }
         it do
-          should contain_file('/var/lib/jenkins/plugins/foo.hpi.pinned').without_ensure
+          should contain_file("#{pdir}/foo.hpi.pinned").without_ensure
         end
       end
       context 'with default pin param' do
         it do
-          should contain_file('/var/lib/jenkins/plugins/foo.hpi.pinned').without_ensure
+          should contain_file("#{pdir}/foo.hpi.pinned").without_ensure
         end
       end
     end

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -115,7 +115,7 @@ describe 'jenkins::plugin' do
     ]}
 
     it do
-      should contain_archive__download('myplug.hpi').with(
+      should contain_archive('myplug.hpi').with(
         :proxy_server => "proxy.company.com:8080",
       )
     end

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -13,9 +13,8 @@ describe 'jenkins::plugin' do
 
   describe 'without version' do
     it do
-      should contain_archive__download('myplug.hpi').with(
-        :url  =>  'https://updates.jenkins-ci.org/latest/myplug.hpi',
-        :user => 'jenkins',
+      should contain_archive('/var/lib/jenkins/plugins/myplug.hpi').with(
+        :source  =>  'https://updates.jenkins-ci.org/latest/myplug.hpi',
       )
     end
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
@@ -25,9 +24,8 @@ describe 'jenkins::plugin' do
     let(:params) { { :version => '1.2.3' } }
 
     it do
-      should contain_archive__download('myplug.hpi').with(
-        :url  =>  'https://updates.jenkins-ci.org/download/plugins/myplug/1.2.3/myplug.hpi',
-        :user => 'jenkins',
+      should contain_archive('/var/lib/jenkins/plugins/myplug.hpi').with(
+        :source  =>  'https://updates.jenkins-ci.org/download/plugins/myplug/1.2.3/myplug.hpi',
       )
     end
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
@@ -37,7 +35,7 @@ describe 'jenkins::plugin' do
     let(:params) { { :version => '1.2.3' } }
     before { facts[:jenkins_plugins] = 'myplug 1.2.3, fooplug 1.4.5' }
 
-    it { should_not contain_archive__download('myplug.hpi') }
+    it { should_not contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
     it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
   end
 
@@ -45,7 +43,7 @@ describe 'jenkins::plugin' do
     let(:params) { { :version => '1.2.3' } }
     before { facts[:jenkins_plugins] = 'fooplug 1.4.5, myplug 1.2.3' }
 
-    it { should_not contain_archive__download('myplug.hpi') }
+    it { should_not contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
     it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
   end
 
@@ -86,7 +84,7 @@ describe 'jenkins::plugin' do
   describe 'with enabled is false' do
     let(:params) { { :enabled => false } }
 
-    it { should contain_archive__download('myplug.hpi') }
+    it { should contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi.disabled').with({
       :ensure => 'present',
@@ -98,7 +96,7 @@ describe 'jenkins::plugin' do
   describe 'with enabled is true' do
     let(:params) { { :enabled => true } }
 
-    it { should contain_archive__download('myplug.hpi') }
+    it { should contain_archive('/var/lib/jenkins/plugins/myplug.hpi') }
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
     it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi.disabled').with({
       :ensure => 'absent',
@@ -107,27 +105,11 @@ describe 'jenkins::plugin' do
     })}
   end
 
-  describe 'with proxy' do
-    let(:pre_condition) { [
-      'class jenkins {
-        $proxy_host = "proxy.company.com"
-        $proxy_port = 8080
-      }',
-      'include jenkins'
-    ]}
-
-    it do
-      should contain_archive__download('myplug.hpi').with(
-        :proxy_server => "proxy.company.com:8080",
-      )
-    end
-  end
-
   describe 'with a custom update center' do
     shared_examples 'execute the right fetch command' do
       it 'should retrieve the plugin' do
-        expect(subject).to contain_archive__download('git.hpi').with({
-          :url => "#{expected_url}",
+        expect(subject).to contain_archive('/var/lib/jenkins/plugins/git.hpi').with({
+          :source => "#{expected_url}",
         })
       end
     end
@@ -181,9 +163,8 @@ describe 'jenkins::plugin' do
   describe 'source' do
     shared_examples 'should download from $source url' do
       it 'should download from $source url' do
-        should contain_archive__download('myplug.hpi').with(
-          :url  => 'http://e.org/myplug.hpi',
-          :user => 'jenkins',
+         should contain_archive('/var/lib/jenkins/plugins/myplug.hpi').with(
+          :source  => 'http://e.org/myplug.hpi',
         )
         .that_requires('File[/var/lib/jenkins/plugins]')
       end
@@ -232,7 +213,7 @@ describe 'jenkins::plugin' do
         should contain_file('/var/lib/jenkins/plugins/foo.hpi.pinned').with(
           :owner => 'jenkins',
           :group => 'jenkins',
-        ).that_requires('Archive::Download[foo.hpi]')
+        ).that_requires('Archive[/var/lib/jenkins/plugins/foo.hpi]')
       end
     end
 
@@ -243,7 +224,7 @@ describe 'jenkins::plugin' do
         should contain_file('/var/lib/jenkins/plugins/foo.jpi.pinned').with(
           :owner => 'jenkins',
           :group => 'jenkins',
-        ).that_requires('Archive::Download[foo.jpi]')
+        ).that_requires('Archive[/var/lib/jenkins/plugins/foo.jpi]')
       end
     end
 
@@ -267,19 +248,6 @@ describe 'jenkins::plugin' do
       end
     end
   end # pinned file extension name
-
-
-  context 'with an updated timeout' do
-    let(:timeout) { 1337 }
-    let(:title) { 'foo' }
-    let(:params) do
-      {
-        :timeout => timeout,
-      }
-    end
-
-    it { should contain_archive__download('foo.hpi').with_timeout(timeout) }
-  end
 
   describe 'deprecated params' do
     [

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -105,6 +105,22 @@ describe 'jenkins::plugin' do
     })}
   end
 
+  describe 'with proxy' do
+    let(:pre_condition) { [
+      'class jenkins {
+        $proxy_host = "proxy.company.com"
+        $proxy_port = 8080
+      }',
+      'include jenkins'
+    ]}
+
+    it do
+      should contain_archive__download('myplug.hpi').with(
+        :proxy_server => "proxy.company.com:8080",
+      )
+    end
+  end
+
   describe 'with a custom update center' do
     shared_examples 'execute the right fetch command' do
       it 'should retrieve the plugin' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../'))
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../lib'))
+$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/fixtures/modules/archive/lib'))
 
 require 'spec/helpers/rspechelpers'
 


### PR DESCRIPTION
Replaces the use of:

- `camptocamp/archive`
- `nanliu/staging`
- `exec` resources using `wget` or `curl`

closes #340 (supersedes)
resolves #427
closes #433 (supersedes)
resolves #505
possibly related to #512