### PR TITLE
attempt to determine the correct gem provider

### DIFF
--- a/manifests/cli/config.pp
+++ b/manifests/cli/config.pp
@@ -23,10 +23,22 @@ class jenkins::cli::config(
   if $cli_try_sleep { validate_numeric($cli_try_sleep) }
   validate_string($ssh_private_key_content)
 
+  if str2bool($::is_pe) {
+    $gem_provider = 'pe_gem'
+  } elsif $::puppetversion
+      and (versioncmp($::puppetversion, '4.0.0') >= 0)
+      and $::rubysitedir
+      and ('/opt/puppetlabs/puppet/lib/ruby' in $::rubysitedir) {
+    # AIO puppet
+    $gem_provider = 'puppet_gem'
+  } else {
+    $gem_provider = 'gem'
+  }
+
   # required by PuppetX::Jenkins::Provider::Clihelper base
   if ! defined(Package['retries']) {
     package { 'retries':
-      provider => 'gem',
+      provider => $gem_provider,
     }
   }
 

--- a/spec/classes/cli/config_spec.rb
+++ b/spec/classes/cli/config_spec.rb
@@ -145,6 +145,41 @@ describe 'jenkins::cli::config', :type => :class do
     end # ssh_private_key_content
   end # parameters
 
-  it { should contain_package('retries').with(:provider => 'gem') }
+  describe 'package gem provider' do
+    context 'is_pe fact' do
+      context 'true' do
+        let(:facts) {{ :is_pe => true }}
+        it { should contain_package('retries').with(:provider => 'pe_gem') }
+      end
 
+      context 'false' do
+        let(:facts) {{ :is_pe => false }}
+        it { should contain_package('retries').with(:provider => 'gem') }
+      end
+    end # 'is_pe fact' do
+
+    context 'puppetversion facts' do
+      context '=> 3.8.4' do
+        let(:facts) {{ :puppetversion => '3.8.4' }}
+        it { should contain_package('retries').with(:provider => 'gem') }
+      end
+
+      context '=> 4.0.0' do
+        let(:facts) {{ :puppetversion => '4.0.0' }}
+        it { should contain_package('retries').with(:provider => 'gem') }
+
+        context 'rubysitedir fact' do
+          context '=> /foo/bar' do
+            before { facts[:rubysitedir] = '/foo/bar' }
+            it { should contain_package('retries').with(:provider => 'gem') }
+          end
+
+          context '=> /opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0' do
+            before { facts[:rubysitedir] = '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0' }
+            it { should contain_package('retries').with(:provider => 'puppet_gem') }
+          end
+        end
+      end
+    end # 'puppetversion facts' do
+  end # 'package gem provider' do
 end


### PR DESCRIPTION
`jenkins::cli::config` currently installs the `retries` gem needed by
the xtypes as a convenience -- it is not clear if functionality should be
in this class at all or if it should merely be a vehicle for passing
data into the catalog.  Puppetserver users will still have to manually
install the `retries` gem as there is no reliable way to determine if an
agent run is configuring a puppet master.

resolves #434 
resolves #498