### PR TITLE
make jenkins_job type cloudbees-folder aware

### DIFF
--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -1,4 +1,5 @@
 require 'puppet/property/boolean'
+require 'pathname'
 
 require 'puppet_x/jenkins/type/cli'
 
@@ -33,4 +34,15 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
       end
     end
   end
+
+  # if the job is contained in a `cloudbees-folder`, autorequire any parent
+  # folder jobs
+  # XXX we can't inspect @resource[:name] or self[:name] here because of
+  # meta-programming funkiness
+  autorequire(:jenkins_job) do
+    folders = []
+    Pathname(self[:name]).dirname.descend { |d| folders << d.to_path }
+    folders
+  end
+
 end # PuppetX::Jenkins::Type::Cli.newtype


### PR DESCRIPTION
If the resource name contains slashes, treat them as a
`cloudbees-folder` path and autorequire all parent folders.

Eg., `foo/bar/myjob` would autorequire the `jenkins_job` resources named
`foo` and `foo/bar`.

relates to #472