### PR TITLE
multiple jenkins_job type improvements

### DIFF
--- a/NATIVE_TYPES_AND_PROVIDERS.md
+++ b/NATIVE_TYPES_AND_PROVIDERS.md
@@ -293,12 +293,17 @@ jenkins_credentials { '150b2895-b0eb-4813-b8a5-3779690c063c':
 
 ```
 jenkins_job { 'job name':
-  config => '<xml config string>',
-  enable => true, # true | false
+  ensure    => 'present', # present | absent
+  enable    => true, # true | false
+  config    => '<xml config string>',
+  show_diff => true, # true | false
 }
 ```
 
-XXX Note that enable is prefetch correctly but the value is ignored when
+Has basic support for the `cloudbees-folder` plugin including automatically
+ordering parent folders before nested jobs.
+
+XXX Note that enable is prefetched correctly but the value is ignored when
 syncing.
 
 ```
@@ -460,9 +465,6 @@ TODO
 
 * determine what to do about `jenkins_job` `enable` parameter which potentially
   breaks idempotency
-
-* add a method to `puppet_helper.groovy` to list all jobs so that `jenkins_job`
-  does not need to make multiple cli invocations when prefetching
 
 * test that the transition from authentication being required to disabled is
   properly handled

--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -123,10 +123,10 @@ class Util {
     def ctor
 
     // if we have a null arg, we don't know how to map that back to a class
-    // (hurray for java) and Class::getDeclaredConstructor() will fail. We are
+    // (hooray for java) and Class::getDeclaredConstructor() will fail. We are
     // being lazy here and trying to match only by the number of arguments.
     //
-    // A better impliementation would try to compare parameter types with null
+    // A better implementation would try to compare parameter types with null
     // matching any class that is an instance of Object
     if (args.any { it == null }) {
       def ctors = c.getDeclaredConstructors()
@@ -268,8 +268,8 @@ class Actions {
     }
 
     // it is not possible to directly set the API token because the user
-    // visible value is actualy a digest of the "plain text" token after it
-    // is unecnrypted.
+    // visible value is actually a digest of the "plain text" token after it
+    // is unencrypted.
     def api_token_plain = conf['api_token_plain']
     if (api_token_plain) {
       assert api_token_plain instanceof String
@@ -835,7 +835,7 @@ class Actions {
     def conf = slurper.parseText(text)
 
     // each key in the hash is a method on the Jenkins singleton.  The key's
-    // value is an object to instatiate and pass to the method.  (currently,
+    // value is an object to instantiate and pass to the method.  (currently,
     // only one parameter is supported)
     conf.each { entry ->
       def methodName = entry.key
@@ -901,7 +901,7 @@ class Actions {
   // get_slaveagent_port
   ////////////////////////
   /*
-   * Print the portnumber of the slave agent
+   * Print the port number of the slave agent
   */
   void get_slaveagent_port() {
     def j = Jenkins.getInstance()

--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -911,6 +911,24 @@ class Actions {
       out.println("Found resource is not a job, skipping.")
     }
   }
+
+  /////////////////////////
+  // get_job_list
+  /////////////////////////
+  /*
+   * Return all the configured jobs as a list of maps
+   */
+  void get_job_list() {
+    def jobs = []
+    Jenkins.getInstance().items.each { job ->
+      def name = job.getName()
+      jobs << [name: name, config: job.getConfigFile().getFile().getText('utf-8'), enabled: !job.isDisabled()]
+    }
+
+    def builder = new groovy.json.JsonBuilder(jobs)
+    out.println(builder.toPrettyString())
+  }
+
 } // class Actions
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/lib/puppet/provider/jenkins_job/cli.rb
+++ b/lib/puppet/provider/jenkins_job/cli.rb
@@ -8,7 +8,10 @@ Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provi
   mk_resource_methods
 
   def self.instances(catalog = nil)
-    jobs = get_jobs(catalog)
+    jobs = job_list_json(catalog)
+
+    Puppet.debug("#{sname} instances: #{jobs.collect {|i| i['name']}}")
+
     jobs.collect do |job|
       new(
         :name   => job['name'],
@@ -53,13 +56,14 @@ Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provi
 
   private
 
+  # currently unused
   def self.list_jobs(catalog = nil)
     cli(['list-jobs'], :catalog => catalog).split
   end
   private_class_method :list_jobs
 
-  def self.get_jobs(catalog = nil)
-    raw = clihelper(['get_job_list'], :catalog => catalog)
+  def self.job_list_json(catalog = nil)
+    raw = clihelper(['job_list_json'], :catalog => catalog)
 
     begin
       JSON.parse(raw)
@@ -67,13 +71,15 @@ Puppet::Type.type(:jenkins_job).provide(:cli, :parent => PuppetX::Jenkins::Provi
       fail("unable to parse as JSON: #{raw}")
     end
   end
-  private_class_method :get_jobs
+  private_class_method :job_list_json
 
+  # currently unused
   def self.get_job(job, catalog = nil)
     cli(['get-job', job], :catalog => catalog)
   end
   private_class_method :get_job
 
+  # currently unused
   def self.job_enabled(job, catalog = nil)
     raw = clihelper(['job_enabled', job], :catalog => catalog)
     !!(raw =~ /true/)

--- a/lib/puppet/type/jenkins_job.rb
+++ b/lib/puppet/type/jenkins_job.rb
@@ -1,5 +1,7 @@
 require 'puppet/property/boolean'
 require 'pathname'
+require 'puppet/util/diff'
+require 'puppet/util/checksums'
 
 require 'puppet_x/jenkins/type/cli'
 
@@ -14,7 +16,31 @@ PuppetX::Jenkins::Type::Cli.newtype(:jenkins_job) do
   end
 
   newproperty(:config) do
+    include Puppet::Util::Diff
+    include Puppet::Util::Checksums
+
     desc 'XML job configuration string'
+
+    def change_to_s(currentvalue, newvalue)
+      if currentvalue == :absent
+        return "created"
+      elsif newvalue == :absent
+        return "removed"
+      else
+        if Puppet[:show_diff] and resource.parameter(:show_diff)
+          send @resource[:loglevel], "\n" + lcs_diff(currentvalue, newvalue)
+        end
+
+        current_md5 = md5(currentvalue)
+        new_md5 = md5(newvalue)
+        return "content changed '{md5}#{current_md5}' to '{md5}#{new_md5}'"
+      end
+    end
+  end
+
+  newparam(:show_diff, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc 'enable/disable displaying configuration diff'
+    defaultto true
   end
 
   newproperty(:enable, :boolean => true, :parent => Puppet::Property::Boolean) do

--- a/spec/acceptance/job_spec.rb
+++ b/spec/acceptance/job_spec.rb
@@ -65,7 +65,7 @@ EOS
 
       jenkins::job { 'test-build-job':
         config  => \'#{test_build_job}\',
-        enabled => 0,
+        enabled => false,
       }
       EOS
 

--- a/spec/acceptance/xtypes/jenkins_job_spec.rb
+++ b/spec/acceptance/xtypes/jenkins_job_spec.rb
@@ -1,0 +1,219 @@
+require 'spec_helper_acceptance'
+
+# a fixed order is required in order to cleanup created jobs -- we are relying
+# on existing state as a performance optimization.
+describe 'jenkins_job', :order => :defined do
+  let(:test_build_job) {
+    example = <<'EOS'
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>test job</description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>/usr/bin/true</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>
+EOS
+    # escape single quotes for puppet
+    example.gsub("'", %q(\\\'))
+  }
+
+  let(:test_folder_job) do
+    example = <<'EOS'
+<?xml version="1.0" encoding="UTF-8"?><com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@5.5">
+  <properties/>
+  <views>
+    <hudson.model.AllView>
+      <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <healthMetrics>
+    <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric/>
+  </healthMetrics>
+  <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>
+EOS
+    # escape single quotes for puppet
+    example.gsub("'", %q(\\\'))
+  end
+
+  let(:base_manifest) do
+    <<-EOS
+      include ::jenkins
+      include ::jenkins::cli::config
+    EOS
+  end
+
+  context 'ensure =>' do
+    context 'present' do
+      it 'should work with no errors' do
+        pp = base_manifest + <<-EOS
+          jenkins_job { 'foo':
+            ensure => present,
+            config => \'#{test_build_job}\',
+          }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      describe file('/var/lib/jenkins/jobs/foo/config.xml') do
+        it { should be_file }
+        it { should be_owned_by 'jenkins' }
+        it { should be_grouped_into 'jenkins' }
+        it { should be_mode 644 }
+        it { should contain '<description>test job</description>' }
+      end
+    end # 'present' do
+
+    context 'absent' do
+      it 'should work with no errors' do
+        pp = base_manifest + <<-EOS
+          jenkins_job { 'foo':
+            ensure => absent,
+          }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      describe file('/var/lib/jenkins/jobs/foo/config.xml') do
+        it { should_not exist }
+      end
+    end # 'absent' do
+  end # 'ensure =>' do
+
+  context 'cloudbees-folder plugin' do
+    let(:manifest) do
+      base_manifest + <<-EOS
+        jenkins::plugin { 'cloudbees-folder': }
+      EOS
+    end
+
+    context 'nested folders' do
+      context 'create' do
+        it 'should work with no errors' do
+          pp = manifest + <<-EOS
+            jenkins_job { 'foo':
+              ensure => present,
+              config => \'#{test_folder_job}\',
+            }
+
+            jenkins_job { 'foo/bar':
+              ensure => present,
+              config => \'#{test_folder_job}\',
+            }
+
+            jenkins_job { 'foo/bar/baz':
+              ensure => present,
+              config => \'#{test_build_job}\',
+            }
+          EOS
+
+          # Run it twice and test for idempotency
+          apply_manifest(pp, :catch_failures => true)
+          apply_manifest(pp, :catch_failures => true)
+        end
+
+        %w{
+          /var/lib/jenkins/jobs/foo/config.xml
+          /var/lib/jenkins/jobs/foo/jobs/bar/config.xml
+        }.each do |config|
+          describe file(config) do
+            it { should be_file }
+            it { should be_owned_by 'jenkins' }
+            it { should be_grouped_into 'jenkins' }
+            it { should be_mode 644 }
+            it { should contain 'cloudbees-folder' }
+          end
+        end
+
+        describe file('/var/lib/jenkins/jobs/foo/jobs/bar/jobs/baz/config.xml') do
+          it { should be_file }
+          it { should be_owned_by 'jenkins' }
+          it { should be_grouped_into 'jenkins' }
+          it { should be_mode 644 }
+          it { should contain '<description>test job</description>' }
+        end
+      end #create
+
+      context 'delete' do
+        it 'should work with no errors' do
+          pp = manifest + <<-EOS
+            jenkins_job { 'foo': ensure => absent }
+            jenkins_job { 'foo/bar': ensure => absent }
+            jenkins_job { 'foo/bar/baz': ensure => absent }
+          EOS
+
+          # Run it twice and test for idempotency
+          apply_manifest(pp, :catch_failures => true)
+          apply_manifest(pp, :catch_failures => true)
+        end
+
+        %w{
+          /var/lib/jenkins/jobs/foo/config.xml
+          /var/lib/jenkins/jobs/foo/jobs/bar/config.xml
+          /var/lib/jenkins/jobs/foo/jobs/bar/jobs/baz/config.xml
+        }.each do |config|
+          describe file(config) { it { should_not exist } }
+        end
+      end #delete
+    end #nested folders
+
+    context 'convert existing job to folder' do
+      it 'should work with no errors' do
+        pending('CLI update-job command is unable to handle the conversion')
+
+        pp = manifest + <<-EOS
+          jenkins_job { 'foo':
+            ensure => present,
+            config => \'#{test_build_job}\',
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+
+        pp = manifest + <<-EOS
+          jenkins_job { 'foo':
+            ensure => present,
+            config => \'#{test_folder_job}\',
+          }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_failures => true)
+
+        # only for cleanup
+        pp = manifest + <<-EOS
+          jenkins_job { 'foo': ensure => absent }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+      end
+    end #convert existing job to folder
+  end #cloudbees-folder
+end #jenkins_job

--- a/spec/unit/puppet/provider/jenkins_job/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_job/cli_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'unit/puppet_x/spec_jenkins_providers'
 
+require 'json'
+
 describe Puppet::Type.type(:jenkins_job).provider(:cli) do
   let(:list_jobs_output) { "foo\nbar\n" }
   let(:foo_xml) do
@@ -31,26 +33,31 @@ describe Puppet::Type.type(:jenkins_job).provider(:cli) do
   let(:bar_xml) do
     foo_xml.sub('<disabled>false</disabled>', '<disabled>true</disabled>')
   end
+  let(:job_list_json_output) do
+    <<-'EOS'
+    [
+        {
+            "name": "enabled-job",
+            "config": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+            "enabled": true
+        },
+        {
+            "name": "disabled-job",
+            "config": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+            "enabled": false
+        }
+    ]
+    EOS
+  end
+  let(:job_list_json_info) { JSON.parse(job_list_json_output) }
 
   include_examples 'confines to cli dependencies'
 
   describe "::instances" do
     context "without any params" do
       before do
-        expect(described_class).to receive(:list_jobs).
-          with(nil) { ['foo', 'bar']}
-
-        expect(described_class).to receive(:get_job).
-          with('foo', nil) { foo_xml }
-
-        expect(described_class).to receive(:job_enabled).
-          with('foo', nil) { true }
-
-        expect(described_class).to receive(:get_job).
-          with('bar', nil) { bar_xml }
-
-        expect(described_class).to receive(:job_enabled).
-          with('bar', nil) { false }
+        expect(described_class).to receive(:job_list_json).
+          with(nil) { job_list_json_info }
       end
 
       it "should return the correct number of instances" do
@@ -62,8 +69,7 @@ describe Puppet::Type.type(:jenkins_job).provider(:cli) do
           described_class.instances[0]
         end
 
-        it { expect(provider.name).to eq 'foo' }
-        it { expect(provider.config).to eq foo_xml }
+        it { expect(provider.name).to eq 'enabled-job' }
         it { expect(provider.enable).to eq true }
       end
 
@@ -72,24 +78,17 @@ describe Puppet::Type.type(:jenkins_job).provider(:cli) do
           described_class.instances[1]
         end
 
-        it { expect(provider.name).to eq 'bar' }
-        it { expect(provider.config).to eq bar_xml }
+        it { expect(provider.name).to eq 'disabled-job' }
         it { expect(provider.enable).to eq false }
       end
     end
 
     context "when called with a catalog param" do
-      it "should pass it on ::list_jobs, ::get_job, & ::job_enabled" do
+      it "should pass it on ::get_job_list" do
         catalog = Puppet::Resource::Catalog.new
 
-        expect(described_class).to receive(:list_jobs).
-          with(kind_of(Puppet::Resource::Catalog)) { ['foo'] }
-
-        expect(described_class).to receive(:get_job).
-          with('foo', kind_of(Puppet::Resource::Catalog))
-
-        expect(described_class).to receive(:job_enabled).
-          with('foo', kind_of(Puppet::Resource::Catalog))
+        expect(described_class).to receive(:job_list_json).
+          with(kind_of(Puppet::Resource::Catalog)) { job_list_json_info }
 
         described_class.instances(catalog)
       end

--- a/spec/unit/puppet/type/jenkins_job_spec.rb
+++ b/spec/unit/puppet/type/jenkins_job_spec.rb
@@ -129,6 +129,37 @@ describe Puppet::Type.type(:jenkins_job) do
         expect(req[1].source).to eq folder2
         expect(req[1].target).to eq job
       end
+
+      it "should autobefore multiple nested parent folder resources",
+          :unless => Puppet.version.to_f < 4.0 do
+        folder1 = described_class.new(
+          :name => 'foo',
+        )
+
+        folder2 = described_class.new(
+          :name => 'foo/bar',
+        )
+
+        job = described_class.new(
+          :name => 'foo/bar/baz',
+        )
+
+        folder1[:ensure] = :absent
+        folder2[:ensure] = :absent
+        job[:ensure] = :absent
+
+        catalog = Puppet::Resource::Catalog.new
+        catalog.add_resource folder1
+        catalog.add_resource folder2
+        catalog.add_resource job
+        req = job.autobefore
+
+        expect(req.size).to eq 2
+        expect(req[0].source).to eq job
+        expect(req[0].target).to eq folder1
+        expect(req[1].source).to eq job
+        expect(req[1].target).to eq folder2
+      end
     end # folders
   end # autorequire
 end

--- a/spec/unit/puppet/type/jenkins_job_spec.rb
+++ b/spec/unit/puppet/type/jenkins_job_spec.rb
@@ -1,12 +1,64 @@
 require 'spec_helper'
 require 'unit/puppet_x/spec_jenkins_types'
 
+TEST_CONFIG1 = <<'EOS'
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>test job</description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>/usr/bin/true</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>
+EOS
+
+TEST_CONFIG2 = <<'EOS'
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>test job</description>
+  <keepDependencies>true</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>true</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>true</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>/usr/bin/true</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>
+EOS
+
 describe Puppet::Type.type(:jenkins_job) do
   before(:each) { Facter.clear }
 
   describe 'parameters' do
     describe 'name' do
       it_behaves_like 'generic namevar', :name
+    end
+
+    describe 'show_diff' do
+      it_behaves_like 'boolean property', :show_diff, true
     end
   end #parameters
 
@@ -19,12 +71,35 @@ describe Puppet::Type.type(:jenkins_job) do
       it_behaves_like 'boolean property', :enable, true
     end
 
-    # unvalidated properties
-    [:config].each do |property|
-      describe "#{property}" do
-        it { expect(described_class.attrtype(property)).to eq :property }
+    describe 'config' do
+      let(:config) { described_class.new(:resource => resource) }
+
+      it { expect(described_class.attrtype('config')).to eq :config }
+
+      [true, false].product([true, false]).each do |cfg, param|
+        describe "and Puppet[:show_diff] is #{cfg} and show_diff => #{param}" do
+          before do
+            Puppet[:show_diff] = cfg
+            resource.stubs(:show_diff?).returns param
+            resource[:loglevel] = "debug"
+          end
+
+          if cfg and param
+            it "should display a diff" do
+              config.expects(:diff).returns("my diff").once
+              config.expects(:debug).with("\nmy diff").once
+              expect(content).not_to be_safe_insync("other content")
+            end
+          else
+            it "should not display a diff" do
+              config.expects(:diff).never
+              expect(content).not_to_be_safe_insync("other content")
+            end
+          end
+        end
       end
     end
+
   end #properties
 
   describe 'autorequire' do

--- a/spec/unit/puppet_x/spec_jenkins_types.rb
+++ b/spec/unit/puppet_x/spec_jenkins_types.rb
@@ -69,6 +69,14 @@ shared_examples 'validated property' do |param, default, allowed|
   end
 end # validated property
 
+shared_examples 'boolean parameter' do |param, default|
+  it 'does not allow non-boolean values' do
+    expect {
+      described_class.new(:name => 'foo', param => 'unknown')
+    }.to raise_error Puppet::ResourceError, /Valid values are true, false/
+  end
+end # boolean parameter
+
 shared_examples 'boolean property' do |param, default|
   it 'does not allow non-boolean values' do
     expect {


### PR DESCRIPTION
Special thanks to @damoxc for a lot of hard work on this implementation.

* a `show_diff` parameter to enable/suppress logging of a jobs XML
`config`.  This follows the same semantics as the core `file` type and
required that the agent has `--show-diff` enabled.

* changes to `config` are now logged in unified diff format

* all jobs are prefeteched from a single `puppet_helper.groovy` method, greatly
reducing run time with even a moderate number of jobs.

* compatibility with the `cloudbees-folder` plugin

* basic beaker acceptance tests

closes #418
resolves #541