### PR TITLE
test if job class responds to #isDisabled in job_list_json

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -947,11 +947,14 @@ class Actions {
     def jobs = util.findJobs(Jenkins.getInstance())
 
     def allInfo = jobs.collect { path, job ->
+      // at least these job classes do not respond to respond to #isDisabled:
+      // - org.jenkinsci.plugins.workflow.job.WorkflowJob
+      // - com.cloudbees.hudson.plugins.folder.Folder
       def enabled = false
-      // folders don't respond to #isDisabled
-      if (job.getClass().getName() != 'com.cloudbees.hudson.plugins.folder.Folder') {
+      if (job.metaClass.respondsTo(job, 'isDisabled')) {
         enabled = !job.isDisabled()
       }
+
       [
         name: path,
         config: job.getConfigFile().getFile().getText('utf-8'),


### PR DESCRIPTION
Instead of special casing classes which are known not to respond to the
`isDisabled()` method, use introspection.

resolves #551