### PR TITLE
Fix path LOCK_FILE

### DIFF
--- a/files/jenkins-slave.RedHat
+++ b/files/jenkins-slave.RedHat
@@ -10,7 +10,7 @@ RETVAL=0
 
 NAME=jenkins-slave
 JENKINS_CONFIG=/etc/sysconfig/$NAME
-LOCK_FILE=/var/lock/$NAME
+LOCK_FILE=/var/lock/subsys/$NAME
 
 # Source function library.
 . /etc/init.d/functions


### PR DESCRIPTION
Corrects the path of the lock file for the operating system to wait for the finalization of the Jenkins case before hanging up.