### PR TITLE
5th parameter is server list for ActiveDirectory

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -730,7 +730,7 @@ class Actions {
               realm.site,
               realm.bindName,
               realm.bindPassword,
-              realm.groupLookupStrategy,
+              realm.server,
             ],
           ],
         ]


### PR DESCRIPTION
Looking at this the 5th parameter is the server string not the GroupLookupStrategy.
The arguments only seem to be taking 5 parameters even though it seems from the init (https://github.com/jenkinsci/active-directory-plugin/blob/8a86022e18cb81dd4bc0e7ae9afd5a8cf048d894/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java#L146) that it might be able to take 6 (https://github.com/jenkinsci/active-directory-plugin/blob/8a86022e18cb81dd4bc0e7ae9afd5a8cf048d894/src/main/java/hudson/plugins/active_directory/ActiveDirectorySecurityRealm.java#L146-L150).