### PR TITLE
#574 allow newline before start of private key

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -376,7 +376,7 @@ class Actions {
       )
     } else {
       def key_source
-      if (private_key.startsWith('-----BEGIN')) {
+      if (private_key =~ /^(\s*)-----BEGIN(.*)/) {
         key_source = new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(private_key)
       } else {
         key_source = new BasicSSHUserPrivateKey.FileOnMasterPrivateKeySource(private_key)


### PR DESCRIPTION
This is a fix/sortof workaround for #574 

I discovered by accident that if you pad your SSH private key with a newline, the CLI helper accepts it as an argument.  Problem is that it gets added as a file path rather than direct input since startsWith doesn't handle the leading newline (but at least it gets added as SOMETHING rather than throwing an arg error).  This change sorts that out. 

P.S. I know we should be using the native types instead but I was getting puppet_x load errors when I tried it  (on 3.8, not 4+) so I went back to this.
