### PR TITLE
fix rubocop conf path syntax warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@
 
 AllCops:
   Exclude:
-    - 'spec/fixtures/**'
+    - 'spec/fixtures/**/*'
     - 'lib/puppet/jenkins/okjson.rb'
 
 Lint/ConditionPosition:


### PR DESCRIPTION
Warning: Deprecated pattern style '/home/jhoblitt/github/puppet-jenkins/spec/fixtures/**' in /home/jhoblitt/github/puppet-jenkins/.rubocop.yml. Change to '/home/jhoblitt/github/puppet-jenkins/spec/fixtures/**/*'.