### PR TITLE
Improve idempotency of credentials define

### DIFF
--- a/manifests/credentials.pp
+++ b/manifests/credentials.pp
@@ -22,12 +22,16 @@ define jenkins::credentials (
   $private_key_or_path = '',
   $ensure = 'present',
   $uuid = '',
+  $unless_tries = 20,
+  $unless_try_sleep = 5,
 ){
   validate_string($password)
   validate_string($description)
   validate_string($private_key_or_path)
   validate_re($ensure, '^present$|^absent$')
   validate_string($uuid)
+  validate_integer($unless_tries, '', 1)
+  validate_integer($unless_try_sleep, '', 1)
 
   include ::jenkins::cli_helper
 
@@ -50,7 +54,7 @@ define jenkins::credentials (
           "'${description}'",
           "'${private_key_or_path}'",
         ],
-        unless  => "\$HELPER_CMD credential_info ${title} | grep ${title}",
+        unless  => "for i in \$(seq 1 ${unless_tries}); do \$HELPER_CMD credential_info ${title} && break || sleep ${unless_try_sleep}; done | grep ${title}",
       }
     }
     'absent': {

--- a/spec/defines/jenkins_credentials_spec.rb
+++ b/spec/defines/jenkins_credentials_spec.rb
@@ -29,13 +29,15 @@ describe 'jenkins::credentials', :type => :define do
 
   describe 'with ensure is present' do
     let(:params) {{
-      :ensure   => 'present',
-      :password => 'mypass',
+      :ensure           => 'present',
+      :password         => 'mypass',
+      :unless_tries     => 2,
+      :unless_try_sleep => 2,
     }}
     it { should contain_jenkins__cli__exec('create-jenkins-credentials-foo').with({
       :command    => [ 'create_or_update_credentials' , "#{title}", "'mypass'",
                        "''", "'Managed by Puppet'", "''" ],
-      :unless     => "\$HELPER_CMD credential_info #{title} | grep #{title}",
+      :unless     => "for i in \$(seq 1 2); do \$HELPER_CMD credential_info #{title} && break || sleep 2; done | grep #{title}",
     })}
   end
 
@@ -51,14 +53,16 @@ describe 'jenkins::credentials', :type => :define do
 
   describe 'with uuid set' do
     let(:params) {{
-      :ensure   => 'present',
-      :password => 'mypass',
-      :uuid     => 'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f',
+      :ensure           => 'present',
+      :password         => 'mypass',
+      :uuid             => 'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f',
+      :unless_tries     => 2,
+      :unless_try_sleep => 2,
     }}
     it { should contain_jenkins__cli__exec('create-jenkins-credentials-foo').with({
       :command    => [ 'create_or_update_credentials' , "#{title}", "'mypass'",
                        "'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f'", "'Managed by Puppet'", "''" ],
-      :unless     => "\$HELPER_CMD credential_info #{title} | grep #{title}",
+      :unless     => "for i in \$(seq 1 2); do \$HELPER_CMD credential_info #{title} && break || sleep 2; done | grep #{title}",
     })}
   end
 


### PR DESCRIPTION
the CLI is flaky, so the 'unless' needs retries as well otherwise we end up unnecessarily reinstalling creds (and reloading jenkins) the first time the CLI doesn't respond due to things like plugin installs and previous restarts/reloads.
