### PR TITLE
Avoid Plugin installation loops 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ can specify a checksum. You can also define a checksum type with
   }
 ```
 
+#### JPI Plugins
+
+When installing jpi plugins, you must make sure that puppet knows the
+extension of the module, otherwise this jenkins module will cleanup 
+and install the plugin on each puppet run. 
+
+```puppet
+  jenkins::plugin { 'cvs':
+    version       => '2.12',
+    digest_string => 'df67d314144bf35366ba9ad29a4bbd38f5b7c4ed',
+    digest_type   => 'sha1',
+    plugin_ext    => 'jpi'
+  }
+```
+
 #### Direct URL
 
 Direct URL from which to download plugin without modification.  This is

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -43,6 +43,17 @@ describe 'jenkins::plugin' do
     it { should contain_file("#{pdir}/myplug.hpi")}
   end
 
+  describe 'with version and plugin_ext hpi' do
+    let(:params) { { :version => '1.2.3', :plugin_ext => 'hpi' } }
+
+    it do
+      should contain_archive('myplug.hpi').with(
+        :source  =>  'https://updates.jenkins-ci.org/download/plugins/myplug/1.2.3/myplug.hpi',
+      )
+    end
+    it { should contain_file("#{pdir}/myplug.hpi")}
+  end
+
   describe 'with version and in middle of jenkins_plugins fact' do
     let(:params) { { :version => '1.2.3' } }
     before { facts[:jenkins_plugins] = 'myplug 1.2.3, fooplug 1.4.5' }
@@ -272,6 +283,30 @@ describe 'jenkins::plugin' do
       end
       context 'with default pin param' do
         it { should contain_file("#{pdir}/foo.hpi.pinned").with_ensure('file') }
+      end
+    end
+
+    describe 'with plugin_ext' do
+      context 'with plugin_ext => hpi' do
+        let(:params) {{ :plugin_ext => 'hpi' } }
+        it { should contain_file("#{pdir}/foo.hpi.pinned").with_ensure('file') }
+        it { should contain_file("#{pdir}/foo.jpi.pinned").with_ensure('absent') }
+        it { should contain_file("#{pdir}/foo.jpi").with_ensure('absent') }
+        it { should contain_file("#{pdir}/foo.jpi.disabled").with_ensure('absent') }
+      end
+      context 'with plugin_ext => jpi' do
+        let(:params) {{ :plugin_ext => 'jpi' } }
+        it { should contain_file("#{pdir}/foo.jpi.pinned").with_ensure('file') }
+        it { should contain_file("#{pdir}/foo.hpi.pinned").with_ensure('absent') }
+        it { should contain_file("#{pdir}/foo.hpi").with_ensure('absent') }
+        it { should contain_file("#{pdir}/foo.hpi.disabled").with_ensure('absent') }
+      end
+      context 'with plugin_ext => undef' do
+        let(:params) {{ } }
+        it { should contain_file("#{pdir}/foo.hpi.pinned").with_ensure('file') }
+        it { should contain_file("#{pdir}/foo.jpi.pinned").with_ensure('absent') }
+        it { should contain_file("#{pdir}/foo.jpi").with_ensure('absent') }
+        it { should contain_file("#{pdir}/foo.jpi.disabled").with_ensure('absent') }
       end
     end
   end # pinned file extension name


### PR DESCRIPTION
Commit 9bf2a1fa7eb66b06b6cb9c8f659019a0dcb46c30 introduced cleanup logic for installed modules. However when you install plugins from jenkins-ci.org (without source => '' parameter), auto detection of jpi/hpi extension does not work (it is always assumed hpi) and this leads to plugin installation loops. 

begin:
  Puppet removes existing .jpi files
  Puppet installs Plugin plugin.hpi file
  Puppet restarts Jenkins
  Jenkins renames .hpi to .jpi 
goto begin:

This fix allows specifying the plugin extension type manually, avoiding those loops.
