### PR TITLE
Add support to specify multiple jenkins credentials with the same username

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -74,6 +74,17 @@ class Util {
     return CredentialsMatchers.firstOrNull(allCreds, idMatcher)
   }
 
+  def findCredentialsByNameOrId(String username, String id="") {
+    def existing_credentials
+ 
+    if ( id != null && id != "" ) {
+      existing_credentials = findCredentialsById(id)
+    } else {
+      existing_credentials = credentials_for_username(username)
+    }
+    return existing_credentials
+  }
+
   def userToMap(User user) {
     def conf = [:]
 
@@ -392,7 +403,7 @@ class Actions {
     }
 
     // Create or update the credentials in the Jenkins instance
-    def existing_credentials = util.credentials_for_username(username)
+    def existing_credentials = util.findCredentialsByNameOrId(username,id)
 
     if(existing_credentials != null) {
       credentials_store.updateCredentials(
@@ -402,6 +413,17 @@ class Actions {
       )
     } else {
       credentials_store.addCredentials(global_domain, credentials)
+    }
+  }
+
+  //////////////////////////
+  // delete credentials by name or id
+  //////////////////////////
+  void delete_credentials_by_name_or_id(String username, String id="") {
+    if ( id != null && id != "" ) {
+      credentials_delete_id(id)
+    } else {
+      delete_credentials(username)
     }
   }
 
@@ -427,8 +449,8 @@ class Actions {
   ////////////////////////
   // current credentials
   ////////////////////////
-  void credential_info(String username) {
-    def credentials = util.credentials_for_username(username)
+  void credential_info(String username, String id="") {
+    def credentials = util.findCredentialsByNameOrId(username, id)
 
     if(credentials == null) {
       return null

--- a/manifests/cli/exec.pp
+++ b/manifests/cli/exec.pp
@@ -6,11 +6,13 @@
 define jenkins::cli::exec(
   $command = $title,
   $unless  = undef,
+  $onlyif  = undef,
 ) {
   if !(is_string($command) or is_array($command)) {
     fail('$command is not a string or an Array.')
   }
   validate_string($unless)
+  validate_string($onlyif)
 
   include ::jenkins
   include ::jenkins::cli_helper
@@ -31,7 +33,7 @@ define jenkins::cli::exec(
     ' '
   )
 
-  if $unless {
+  if $unless or $onlyif {
     $environment_run = [ "HELPER_CMD=${::jenkins::cli_helper::helper_cmd}" ]
   } else {
     $environment_run = undef
@@ -42,6 +44,7 @@ define jenkins::cli::exec(
     command     => $run,
     environment => $environment_run,
     unless      => $unless,
+    onlyif      => $onlyif,
     tries       => $::jenkins::cli_tries,
     try_sleep   => $::jenkins::cli_try_sleep,
     notify      => Class['jenkins::cli::reload'],

--- a/manifests/credentials.pp
+++ b/manifests/credentials.pp
@@ -45,7 +45,7 @@ define jenkins::credentials (
   
   ## Allow multiple users with same username but different credentials
   if $uuid == '' {
-    $_exec_comment      = ${_username}
+    $_exec_comment      = $_username
     $_exec_grep_present = "\\\"${_username}\\\""
     $_exec_grep_absent  = "\\\"${_username}\\\""
   } else {

--- a/manifests/credentials.pp
+++ b/manifests/credentials.pp
@@ -18,11 +18,11 @@
 #
 define jenkins::credentials (
   $username            = undef,
-  $password,
   $description         = 'Managed by Puppet',
   $private_key_or_path = '',
   $ensure              = 'present',
   $uuid                = '',
+  $password,
 ){
   validate_string($password)
   validate_string($description)
@@ -45,7 +45,7 @@ define jenkins::credentials (
   
   ## Allow multiple users with same username but different credentials
   if $uuid == '' {
-    $_exec_comment      = "${_username}"
+    $_exec_comment      = ${_username}
     $_exec_grep_present = "\\\"${_username}\\\""
     $_exec_grep_absent  = "\\\"${_username}\\\""
   } else {
@@ -67,7 +67,7 @@ define jenkins::credentials (
           "'${description}'",
           "'${private_key_or_path}'",
         ],
-        unless  => "\$HELPER_CMD credential_info '${_username}' '${uuid}' | grep -e $_exec_grep_present",
+        unless  => "\$HELPER_CMD credential_info '${_username}' '${uuid}' | grep -e ${_exec_grep_present}",
       }
     }
     'absent': {
@@ -77,7 +77,7 @@ define jenkins::credentials (
           $_username,
           "'${uuid}'",
         ],
-        onlyif => "\$HELPER_CMD credential_info '${_username}' '${uuid}' | grep -e $_exec_grep_absent",
+        onlyif  => "\$HELPER_CMD credential_info '${_username}' '${uuid}' | grep -e ${_exec_grep_absent}",
       }
     }
     default: {

--- a/spec/defines/jenkins_credentials_spec.rb
+++ b/spec/defines/jenkins_credentials_spec.rb
@@ -35,7 +35,7 @@ describe 'jenkins::credentials', :type => :define do
     it { should contain_jenkins__cli__exec('create-jenkins-credentials-foo').with({
       :command    => [ 'create_or_update_credentials' , "#{title}", "'mypass'",
                        "''", "'Managed by Puppet'", "''" ],
-      :unless     => "\$HELPER_CMD credential_info #{title} | grep #{title}",
+      :unless     => "\$HELPER_CMD credential_info '#{title}' '' | grep -e \\\"#{title}\\\"",
     })}
   end
 
@@ -45,7 +45,20 @@ describe 'jenkins::credentials', :type => :define do
       :password => 'mypass',
     }}
     it { should contain_jenkins__cli__exec('delete-jenkins-credentials-foo').with({
-      :command    => [ 'delete_credentials', "#{title}" ],
+      :command    => [ 'delete_credentials_by_name_or_id', "#{title}", "''" ],
+      :onlyif     => "\$HELPER_CMD credential_info '#{title}' '' | grep -e \\\"#{title}\\\"",
+     })}
+  end
+
+  describe 'with ensure is absent and uuid set' do
+    let(:params) {{
+      :ensure   => 'absent',
+      :password => 'mypass',
+      :uuid     => 'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f',
+    }}
+    it { should contain_jenkins__cli__exec('delete-jenkins-credentials-foo-e94d3b98-5ba4-43b9-89ed-79a08ea97f6f').with({
+      :command    => [ 'delete_credentials_by_name_or_id', "#{title}", "'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f'" ],
+      :onlyif     => "\$HELPER_CMD credential_info '#{title}' 'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f' | grep -e \\\"e94d3b98-5ba4-43b9-89ed-79a08ea97f6f\\\"",
     })}
   end
 
@@ -55,11 +68,26 @@ describe 'jenkins::credentials', :type => :define do
       :password => 'mypass',
       :uuid     => 'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f',
     }}
-    it { should contain_jenkins__cli__exec('create-jenkins-credentials-foo').with({
+    it { should contain_jenkins__cli__exec('create-jenkins-credentials-foo-e94d3b98-5ba4-43b9-89ed-79a08ea97f6f').with({
       :command    => [ 'create_or_update_credentials' , "#{title}", "'mypass'",
                        "'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f'", "'Managed by Puppet'", "''" ],
-      :unless     => "\$HELPER_CMD credential_info #{title} | grep #{title}",
+      :unless     => "\$HELPER_CMD credential_info '#{title}' 'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f' | grep -e \\\"#{title}\\\"",
     })}
   end
+
+  describe 'with username and uuid set' do
+    let(:params) {{
+      :username => 'mytest',
+      :ensure   => 'present',
+      :password => 'mypass',
+      :uuid     => 'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f',
+    }}
+    it { should contain_jenkins__cli__exec('create-jenkins-credentials-mytest-e94d3b98-5ba4-43b9-89ed-79a08ea97f6f').with({
+      :command    => [ 'create_or_update_credentials' , "mytest", "'mypass'",
+                       "'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f'", "'Managed by Puppet'", "''" ],
+      :unless     => "\$HELPER_CMD credential_info 'mytest' 'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f' | grep -e \\\"mytest\\\"",
+    })}
+  end
+
 
 end


### PR DESCRIPTION
Sometimes it is needed to have multiple credential sets in Jenkins using the same username but different passwords. This is the case, when using JFrog artifactory, here you need encrypted passwords to access artifactory, while you need plain plassword to access stash. (Both services AD integrated as common in larger enterprises). 

This fix adds support to specify multiple credentials with same username but different uuid. It also fixed the remove logic (making it idempotent) and fixes the matching for usernames (more specifiy grep expression).

Same result that is fixed by this commit can be achieved using the new experimental resource type jenkins_credentials, however this  resource type does not work on PuppetServer using jruby as due to puppet_x library location (https://tickets.puppetlabs.com/browse/SERVER-973). 