### PR TITLE
Escape +'s when grepping through jenkins plugin version numbers

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -70,7 +70,14 @@ define jenkins::plugin(
       default => $update_url,
     }
     $base_url = "${plugins_host}/download/plugins/${name}/${version}/"
-    $search   = "^${name} ${version}$"
+    # Escape +'s in $version when constructing $search.
+    # * We can't use single quotes for the replacement string because
+    #   puppet 3 and puppet 4 interpret '\\' differently.
+    # * We can't use double quotes without a variable interpolation or
+    #   lint complains.
+    $empty    = ''
+    $escver   = regsubst ($version, '\+', "${empty}\\\\+", 'G')
+    $search   = "^${name} ${escver}$"
   }
   else {
     $plugins_host = $update_url ? {

--- a/spec/defines/jenkins_plugin_spec.rb
+++ b/spec/defines/jenkins_plugin_spec.rb
@@ -91,6 +91,14 @@ describe 'jenkins::plugin' do
       it { should contain_archive('myplug.hpi') }
       it { should contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
     end
+
+    describe 'where version contains a + and is already installed' do
+      let(:params) { { :version => '1.2+3.4' } }
+      before { facts[:jenkins_plugins] = 'myplug 1.2+3.4' }
+
+      it { should_not contain_archive('myplug.hpi') }
+      it { should_not contain_file('/var/lib/jenkins/plugins/myplug.hpi')}
+    end
   end # 'with name and version'
 
   describe 'with enabled is false' do


### PR DESCRIPTION
For some reason, the maintainers of the jenkins "Build Monitoring Plugin" (https://wiki.jenkins-ci.org/display/JENKINS/Build+Monitor+Plugin) decided to put a "+" in their version names (e.g., "1.9+build.201606052339"). This confuses the logic that uses grep to search for installed plugins. The "+" is interpreted as a special regexp character, so no match is found, and puppet tries to install the plugin (and restart jenkins) over and over again. This fix escapes +'s in the search string before it's passed to grep.