### PR TITLE
-- #573: Convert jenkins::slave::java_args to support both strings and arrays.

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -70,7 +70,8 @@
 #   File source for jenkins slave jar. Default pulls from http://maven.jenkins-ci.org
 #
 # [*java_args*]
-#   Java arguments to add to slave command line. Allows configuration of heap, etc.
+#   Java arguments to add to slave command line. Allows configuration of heap, etc. This
+#   can be a String, or an Array.
 #
 
 # === Examples
@@ -78,7 +79,7 @@
 #  class { 'jenkins::slave':
 #    masterurl => 'http://jenkins-master1.example.com:8080',
 #    ui_user => 'adminuser',
-#    ui_pass => 'adminpass',
+#    ui_pass => 'adminpass'
 #  }
 #
 # === Authors
@@ -132,7 +133,6 @@ class jenkins::slave (
   validate_re($ensure, '^running$|^stopped$')
   validate_bool($enable)
   validate_string($source)
-  validate_string($java_args)
 
   $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"
   $client_url = $source ? {
@@ -152,6 +152,15 @@ class jenkins::slave (
     }
   }
 
+  if $java_args {
+    if is_array($java_args) {
+      $_combined_java_args = hiera_array('jenkins::slave::java_args', $java_args)
+      $_real_java_args = join($_combined_java_args, ' ')
+    }
+    else {
+      $_real_java_args = $java_args
+    }
+  }
 
   if $install_java and ($::osfamily != 'Darwin') {
     # Currently the puppetlabs/java module doesn't support installing Java on

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -80,7 +80,7 @@ describe 'jenkins::slave' do
       end
     end
 
-    describe 'with java_args' do
+    describe 'with java_args as a string' do
       let(:args) { '-Xmx2g' }
       let(:params) do
         {
@@ -90,6 +90,20 @@ describe 'jenkins::slave' do
 
       it 'should set java_args' do
         should contain_file(slave_runtime_file).with_content(/^JAVA_ARGS="#{args}"$/)
+      end
+    end
+
+    describe 'with java_args as an array' do
+      let(:args) { ['-Xmx2g', '-Xms128m' ] }
+      let(:params) do
+        {
+          :java_args => args
+        }
+      end
+
+      it 'should convert java_args to a string' do
+        args_as_string = args.join ' '
+        should contain_file(slave_runtime_file).with_content(/^JAVA_ARGS="#{args_as_string}"$/)
       end
     end
 

--- a/templates/jenkins-slave-defaults.erb
+++ b/templates/jenkins-slave-defaults.erb
@@ -9,8 +9,8 @@ JAVA=/usr/bin/java
 # arguments to pass to java
 #JAVA_ARGS="-Xmx256m"
 #JAVA_ARGS="-Djava.net.preferIPv4Stack=true" # make jenkins listen on IPv4 address
-<% if @java_args -%>
-JAVA_ARGS="<%= @java_args -%>"
+<% if @_real_java_args -%>
+JAVA_ARGS="<%= @_real_java_args -%>"
 <% end -%>
 
 PIDFILE=/var/run/jenkins-slave/jenkins-slave.pid


### PR DESCRIPTION
This change will allow users to use 'jenkins::slave::java_args' as a string, or array. With support for hiera_array merging; based on hiera config.