### PR TITLE
Adding LDAP as a user realm.

### DIFF
--- a/templates/ldap_args.json.erb
+++ b/templates/ldap_args.json.erb
@@ -1,0 +1,1 @@
+<%= require 'json'; JSON.pretty_generate(@ldapconfig) %>


### PR DESCRIPTION
By setting the user_realm to ldap and passing in the necessary config fields in ldapconfig through hiera for example then puppet will manage the ldap config.

Parameters to be set in the $ldapconfig hash:

    server                     => "",
    rootDN                     => "",
    userSearch                 => "",
    managerDN                  => "",
    managerPasswordSecret      => "",
    inhibitInferRootDN         => "",
    disableMailAddressResolver => "",
    displayNameAttributeName   => "",
    mailAddressAttributeName   => ""

These will be loaded into a json file and then used by the puppet_helper groovy script to pass these arguments to the LDAPSecurityRealm constructor function.