### PR TITLE
Fix tool_locations bash via doublequotes

### DIFF
--- a/templates/jenkins-slave-defaults.erb
+++ b/templates/jenkins-slave-defaults.erb
@@ -84,7 +84,7 @@ fi
 <% if @tool_locations %>
   TOOL_LOCATIONS_ARG=""
   <% @tool_locations.split.each do |tool_location| %>
-    TOOL_LOCATIONS_ARG='$TOOL_LOCATIONS_ARG --toolLocation <%= tool_location.split(':').first -%>=<%= tool_location.split(':').last -%>'
+    TOOL_LOCATIONS_ARG="$TOOL_LOCATIONS_ARG --toolLocation <%= tool_location.split(':').first -%>=<%= tool_location.split(':').last -%>"
   <% end %>
 <% end %>
 


### PR DESCRIPTION
#367 introduced single quotes.  Can't work for multiple tool_locations in the current state since only the last statement will get used.