### PR TITLE
Use a up-to-date swarm client URL

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -144,7 +144,7 @@ class jenkins::slave (
 
   $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"
   $client_url = $source ? {
-    undef   => "http://maven.jenkins-ci.org/content/repositories/releases/org/jenkins-ci/plugins/swarm-client/${version}/",
+    undef   => "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${version}/",
     default => $source,
   }
   $quoted_ui_user = shellquote($ui_user)


### PR DESCRIPTION
maven.jenkins-ci.org has been deprecated and redirecting to repo.jenkins-ci.org for *years*