### PR TITLE
Pin the loose dependency (from hiera) on json_pure to something less than 2.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'metadata-json-lint'
 gem 'retries', '~> 0.0.5'
 gem 'travis', '~> 1.8'
 gem 'parallel_tests'
-gem 'rubocop', '~> 0.39'
+gem 'rubocop', '< 0.42.0'
 
 gem 'json_pure', '< 2.0.2'
 
@@ -23,7 +23,7 @@ group :development do
   gem 'debugger-pry', :platform => :mri_19
   gem 'byebug', :platform => [:mri_20, :mri_21]
   gem 'pry'
-  gem 'pry-byebug'
+  gem 'pry-byebug', :platform => [:mri_20, :mri_21]
 end
 
 group :system_tests do

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'travis', '~> 1.8'
 gem 'parallel_tests'
 gem 'rubocop', '~> 0.39'
 
+gem 'json_pure', '< 2.0.2'
+
 group :development do
   gem 'simplecov'
   gem 'ci_reporter'


### PR DESCRIPTION
2.0.1 requires Ruby version: >= 0

2.0.2 requires Ruby version: ~> 2.0

FUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU

https://twitter.com/agentdero/status/765587955612160001