### PR TITLE
Plugins fail to install due to search false positives

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -85,7 +85,7 @@ define jenkins::plugin(
       default => $update_url,
     }
     $base_url = "${plugins_host}/latest/"
-    $search   = "${name} "
+    $search   = "^${name} "
   }
 
   # if $source is specified, it overrides any other URL construction


### PR DESCRIPTION
This change brings the regex pattern for plugin (without version) search inline with the regex pattern for plugin+version search on line 80.

Without the prepended caret (^), plugins that are not installed may fail to install due to false positives.  Example:

* Install the `ssh-credentials` plugin
* Install the `credentials` plugin

With the current logic, the regex "credentials" will match the existing plugin "ssh-credentials" and the plugin will not be installed.  Adding a ^ fixes this issue.