### PR TITLE
Move jenkins::params::default_plugins to class param

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,9 @@
 # Class: jenkins::params
 #
 #
-class jenkins::params {
+class jenkins::params(
+  $default_plugins = [ 'credentials' ], # required by puppet_helper.groovy
+) {
   $version               = 'installed'
   $lts                   = true
   $repo                  = true
@@ -26,9 +28,6 @@ class jenkins::params {
   $manage_group = true
   $group        = 'jenkins'
   $_java_args   = '-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false'
-  $default_plugins = [
-    'credentials', # required by puppet_helper.groovy
-  ]
 
   case $::osfamily {
     'Debian': {

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -289,5 +289,14 @@ describe 'jenkins', :type => :module do
         end
       end
     end # manages state dirs
+
+    describe 'with default plugins' do
+      it { should contain_jenkins__plugin 'credentials' }
+    end
+
+    describe 'with default plugins override' do
+      let (:pre_condition) { 'class { ::jenkins::params: default_plugins => [] }' }
+      it { should_not contain_jenkins__plugin 'credentials' }
+    end
   end
 end


### PR DESCRIPTION
Without this patch the configuration does not converge.  The credentials plugin
is downloaded and installed every configuration run.  This patch addresses the
problem by making it possible to override the default configuration of the
credentials plugin with the following hiera data:

```
jenkins::params::default_plugins: []
jenkins::plugin_hash:
  credentials:
    version: 2.1.5
    digest_string: 7db002e7b053f863e2ce96fb58abb98a9c01b09c
    digest_type: sha1
```
