### PR TITLE
Avoid "Undefined variable 'proxy_server'" warnings.

### DIFF
--- a/manifests/direct_download.pp
+++ b/manifests/direct_download.pp
@@ -10,6 +10,8 @@ class jenkins::direct_download {
   validate_string($::jenkins::direct_download)
   validate_absolute_path($::jenkins::package_cache_dir)
 
+  include ::jenkins::proxy
+
   # directory for temp files
   file { $::jenkins::package_cache_dir:
     ensure => directory,
@@ -29,7 +31,7 @@ class jenkins::direct_download {
     archive { $package_file:
       source       => $jenkins::direct_download,
       path         => $local_file,
-      proxy_server => $::jenkins::proxy_server,
+      proxy_server => $::jenkins::proxy::url,
       cleanup      => false,
       extract      => false,
       before       => Package[$::jenkins::package_name],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,20 +268,7 @@ class jenkins(
   include jenkins::plugins
   include jenkins::jobs
   include jenkins::users
-
-  if $proxy_host and $proxy_port {
-    class { 'jenkins::proxy':
-      require => Package['jenkins'],
-      notify  => Service['jenkins']
-    }
-
-    # param format needed by puppet/archive
-    $proxy_server = "http://${jenkins::proxy_host}:${jenkins::proxy_port}"
-  } else {
-    $proxy_server = undef
-  }
-
-
+  include jenkins::proxy
   include jenkins::service
 
   if defined('::firewall') {

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -172,7 +172,7 @@ define jenkins::plugin(
       checksum_verify => $checksum_verify,
       checksum        => $checksum,
       checksum_type   => $digest_type,
-      proxy_server    => $::jenkins::proxy_server,
+      proxy_server    => $::jenkins::proxy::url,
       cleanup         => false,
       extract         => false,
       require         => File[$::jenkins::plugin_dir],

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -10,11 +10,25 @@ class jenkins::proxy {
   $proxy_port = $::jenkins::proxy_port
   $no_proxy_list = $::jenkins::no_proxy_list
 
-  file { "${::jenkins::localstatedir}/proxy.xml":
-    content => template('jenkins/proxy.xml.erb'),
-    owner   => $::jenkins::user,
-    group   => $::jenkins::group,
-    mode    => '0644'
+  if $proxy_host and $proxy_port {
+
+    # param format needed by puppet/archive
+    $url = "http://${proxy_host}:${proxy_port}"
+    $proxy_xml = "${::jenkins::localstatedir}/proxy.xml"
+
+    file { $proxy_xml:
+      content => template('jenkins/proxy.xml.erb'),
+      owner   => $::jenkins::user,
+      group   => $::jenkins::group,
+      mode    => '0644'
+    }
+
+    Package['jenkins'] ->
+    File[$proxy_xml] ~>
+    Service['jenkins']
+
+  } else {
+    $url = undef
   }
 
 }

--- a/spec/classes/jenkins_proxy_spec.rb
+++ b/spec/classes/jenkins_proxy_spec.rb
@@ -12,7 +12,7 @@ describe 'jenkins', :type => :module do
 
   context 'proxy' do
     context 'default' do
-      it { should_not contain_class('jenkins::proxy') }
+      it { should contain_class('jenkins::proxy') }
     end
 
     context 'with basic proxy config' do

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -21,7 +21,7 @@ describe 'jenkins', :type => :module do
       it { should contain_class 'jenkins::plugins' }
       it { should contain_class 'jenkins::service' }
       it { should_not contain_class 'jenkins::firewall' }
-      it { should_not contain_class 'jenkins::proxy' }
+      it { should contain_class 'jenkins::proxy' }
       it { should contain_class 'jenkins::repo' }
       it { should contain_class 'jenkins::repo::el' }
       it { should_not contain_class 'jenkins::repo::debian' }
@@ -40,12 +40,12 @@ describe 'jenkins', :type => :module do
 
     describe 'with only proxy host' do
       let(:params) { { :proxy_host => '1.2.3.4' } }
-      it { should_not contain_class('jenkins::proxy') }
+      it { should contain_class('jenkins::proxy') }
     end
 
     describe 'with only proxy_port' do
       let(:params) { { :proxy_port => 1234 } }
-      it { should_not contain_class('jenkins::proxy') }
+      it { should contain_class('jenkins::proxy') }
     end
 
     describe 'with proxy_host and proxy_port' do


### PR DESCRIPTION
These changes avoid one or many warnings:

Warning: Undefined variable 'proxy_server'; 
 (file & line not available)

...from direct_download.pp and plugin.pp. I was seeing warnings from direct_download.pp when using direct_download but not using a proxy. I'm using puppet 4.7.0.