### PR TITLE
Remove quotes for fsroot as it breaks paths in Darwin

### DIFF
--- a/templates/jenkins-slave-defaults.erb
+++ b/templates/jenkins-slave-defaults.erb
@@ -78,7 +78,7 @@ if [ -n "$LABELS" ]; then
 fi
 
 if [ -n "$FSROOT" ]; then
-  FSROOT_ARG="-fsroot '$FSROOT'"
+  FSROOT_ARG="-fsroot $FSROOT"
 fi
 
 <% if @tool_locations %>


### PR DESCRIPTION
Tested on osx 10.11. When quotes are used, fsroot env variable is broken (eg. `/opt/jenkins'/opt/jenkins/'jenkins` instead of just `/opt/jenkins`
