### PR TITLE
#652: Adjust how the LABELS_ARG variable gets set to avoid over quoting.

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -79,6 +79,11 @@
 #   parameter so the `::jenkins` class does not need to be the catalog for
 #   slave only nodes.
 #
+# [*slave_args*]
+#
+#   This takes a string, or an array, of additional arguments to pass into the Jenkins
+#   swarm client. Please see your version of the Swarm client for available options.
+#
 
 # === Examples
 #
@@ -119,6 +124,7 @@ class jenkins::slave (
   $source                   = undef,
   $java_args                = undef,
   $proxy_server             = undef,
+  $slave_args               = undef,
 ) inherits jenkins::params {
   validate_string($slave_name)
   validate_string($description)
@@ -167,6 +173,16 @@ class jenkins::slave (
     }
     else {
       $_real_java_args = $java_args
+    }
+  }
+
+  if $slave_args {
+    if is_array($slave_args) {
+      $_combined_slave_args = hiera_array('jenkins::slave::slave_args', $slave_args)
+      $_real_slave_args = join($_combined_slave_args, ' ')
+    }
+    else {
+      $_real_slave_args = $slave_args
     }
   }
 

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -130,6 +130,30 @@ describe 'jenkins::slave' do
         should contain_file(slave_runtime_file).with_content(/^LABELS="unlimited blades"$/)
       end
     end
+
+    describe 'with SLAVE_ARGS as an array' do
+      let(:params) do
+        {
+          :slave_args => ['-deleteExistingClients', '-disableClientsUniqueId']
+        }
+      end
+
+      it 'should set SLAVE_ARGS as a string' do
+        should contain_file(slave_runtime_file).with_content(/^OTHER_ARGS="(\s?)-deleteExistingClients -disableClientsUniqueId"$/)
+      end
+    end
+
+    describe 'with SLAVE_ARGS as a string' do
+      let(:params) do
+        {
+          :slave_args => ['-deleteExistingClients -disableClientsUniqueId']
+        }
+      end
+
+      it 'should set SLAVE_ARGS as a string' do
+        should contain_file(slave_runtime_file).with_content(/^OTHER_ARGS="(\s?)-deleteExistingClients -disableClientsUniqueId"$/)
+      end
+    end
   end
 
   shared_examples 'using slave_name' do

--- a/templates/jenkins-slave-defaults.erb
+++ b/templates/jenkins-slave-defaults.erb
@@ -74,7 +74,7 @@ if [ -n "$MASTER_URL" ]; then
 fi
 
 if [ -n "$LABELS" ]; then
-  LABELS_ARG="-labels '$LABELS'"
+  LABELS_ARG="-labels \"${LABELS//\"}\""
 fi
 
 if [ -n "$FSROOT" ]; then

--- a/templates/jenkins-slave-defaults.erb
+++ b/templates/jenkins-slave-defaults.erb
@@ -59,7 +59,7 @@ DESCRIPTION="<%= @description -%>"
 JENKINS_USERNAME=<%= @quoted_ui_user %>
 JENKINS_PASSWORD=<%= @quoted_ui_pass %>
 
-OTHER_ARGS="<%= '-disableSslVerification' if @disable_ssl_verification -%>"
+OTHER_ARGS="<%= '-disableSslVerification' if @disable_ssl_verification -%> <%= @_real_slave_args unless @_real_slave_args.nil? -%>"
 
 if [ -n "$JENKINS_USERNAME" ]; then
   CREDENTIALS_ARG="-username $JENKINS_USERNAME -password $JENKINS_PASSWORD"


### PR DESCRIPTION
When setting the variable `LABELS_ARG` strip quotes from the the variable `LABELS` to avoid over quoting.