### PR TITLE
Add support for disabling management of Service[jenkins]

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -18,9 +18,11 @@ class jenkins::cli {
   #
   # As an attempt to preserve backwards compatibility, there are includes and
   # resource relationships being scattered throughout this module.
-  Class['jenkins::service'] ->
-    Class['jenkins::cli'] ->
-      Anchor['jenkins::end']
+  if $::jenkins::manage_service {
+    Class['jenkins::service'] ->
+      Class['jenkins::cli'] ->
+        Anchor['jenkins::end']
+  }
 
   $jar = "${jenkins::libdir}/jenkins-cli.jar"
   $extract_jar = "jar -xf ${jenkins::libdir}/jenkins.war WEB-INF/jenkins-cli.jar"

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -183,6 +183,23 @@ describe 'jenkins', :type => :module do
       end
     end # manage_user =>
 
+
+    describe 'manage_service =>' do
+      context '(default)' do
+        it { should contain_class 'jenkins::service' }
+      end
+
+      context 'false' do
+        let(:params) do
+          {
+            :manage_service => false,
+          }
+        end
+        it { should_not contain_class 'jenkins::service' }
+        it { should_not contain_service 'jenkins' }
+      end
+    end # manage_service =>
+
     describe 'user =>' do
       context '(default)' do
         it do


### PR DESCRIPTION
This is especially useful when deploying Jenkins from a Docker container, but
still wishing to use some of the great abstractions around job/user/etc
management in this module.

This doesn't change the expectation that /something/ will implement
Service[jenkins] in the catalog, as that would make the implementation of types
like jenkins::cli::exec obscenely complex (and maybe not even possible).