### PR TITLE
Newer versions of parallel_tests require Ruby 2.0 or newer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'puppet', ENV['PUPPET_VERSION'] || '~> 4.7'
 gem 'metadata-json-lint'
 gem 'retries', '~> 0.0.5'
 gem 'travis', '~> 1.8'
-gem 'parallel_tests'
+gem 'parallel_tests', :platform => [:mri_20, :mri_21]
 gem 'rubocop', '< 0.42.0'
 
 gem 'json_pure', '< 2.0.2'

--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,6 @@ require 'rake'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
-require 'parallel_tests'
-require 'parallel_tests/cli'
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
@@ -49,12 +47,19 @@ namespace :travis do
   end
 end
 
-desc 'Parallel spec tests'
-task :parallel_spec do
-  Rake::Task[:spec_prep].invoke
-  ParallelTests::CLI.new.run('--type test -t rspec spec/classes spec/defines spec/unit spec/functions'.split)
-  Rake::Task[:spec_clean].invoke
+begin
+  require 'parallel_tests'
+  require 'parallel_tests/cli'
+  desc 'Parallel spec tests'
+  task :parallel_spec do
+    Rake::Task[:spec_prep].invoke
+    ParallelTests::CLI.new.run('--type test -t rspec spec/classes spec/defines spec/unit spec/functions'.split)
+    Rake::Task[:spec_clean].invoke
+  end
+rescue LoadError
+  task :parallel_spec => [:spec]
 end
+
 
 task :default => [
   :rubocop,


### PR DESCRIPTION
This platform locks parallel_tests so only newer Rubies can make use of it, yey