### PR TITLE
adding service_provider for EL7 for jenkins-slave service

### DIFF
--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -90,6 +90,9 @@
 #   parameter so the `::jenkins` class does not need to be the catalog for
 #   slave only nodes.
 #
+# [*service_provider*]
+#   Service provider for jenkins-slave service.
+#
 
 # === Examples
 #
@@ -132,6 +135,7 @@ class jenkins::slave (
   $source                    = undef,
   $java_args                 = undef,
   $proxy_server              = undef,
+  $service_provider          = $jenkins::params::service_provider,
 ) inherits jenkins::params {
   validate_string($slave_name)
   validate_string($description)
@@ -155,6 +159,7 @@ class jenkins::slave (
   validate_bool($enable)
   validate_string($source)
   validate_string($proxy_server)
+  validate_string($service_provider)
 
   $client_jar = "swarm-client-${version}-jar-with-dependencies.jar"
   $client_url = $source ? {
@@ -303,6 +308,7 @@ class jenkins::slave (
     ensure     => $ensure,
     name       => $service_name,
     enable     => $enable,
+    provider   => $service_provider,
     hasstatus  => true,
     hasrestart => true,
   }

--- a/spec/classes/jenkins_slave_service_spec.rb
+++ b/spec/classes/jenkins_slave_service_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'jenkins::slave', :type => :module  do
+  let(:facts) do
+    {
+      :osfamily                  => 'RedHat',
+      :operatingsystem           => 'RedHat',
+      :operatingsystemrelease    => '6.7',
+      :operatingsystemmajrelease => '6',
+    }
+  end
+
+  context 'service' do
+    context 'default' do
+      it { should contain_service('jenkins-slave').with(:ensure => 'running', :enable => true) }
+    end
+    context 'EL 7' do
+      let(:facts) do
+        super().merge( {:operatingsystemrelease => '7.1.1503', :operatingsystemmajrelease => '7'})
+      end
+      it { should contain_service('jenkins-slave').with(:ensure => 'running', :enable => true, :provider => 'redhat') }
+    end
+    context 'EL 6' do
+      let(:facts) do
+        super().merge( {:operatingsystemrelease => '6.6', :operatingsystemmajrelease => '6'})
+      end
+      it { should contain_service('jenkins-slave').with(:ensure => 'running', :enable => true) }
+    end
+    context 'managing service' do
+      let(:params) { { :ensure => 'stopped', :enable => false } }
+      it { should contain_service('jenkins-slave').with(:ensure => 'stopped', :enable => false ) }
+    end
+  end
+
+end


### PR DESCRIPTION
For consistency sake, if we are using service_provider for the `jenkins` master service, we should probably add the ability to use it for the `jenkins-slave` service on the slaves as well. 