### PR TITLE
Add support for gitlab api token credential - #664

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -509,6 +509,10 @@ class Actions {
           info['private_key'] = cred.privateKey
           info['passphrase'] = cred.passphrase.plainText
           break
+        case 'com.dabsquared.gitlabjenkins.connection.GitLabApiTokenImpl':
+          info['apiToken'] = cred.apiToken.plainText
+          info['description'] = cred.description
+          break
         case 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl':
           info['description'] = cred.description
           info['secret'] = cred.secret.plainText


### PR DESCRIPTION
Add gitlab token api credential to switch statement for
credentials_list_json in the puppet_helper.groovy script.
Without this, the credentials native type fails with an
unsupported credentials error if you have a gitlab api
token in your credentials list.