### PR TITLE
add ::jenkins::sysconfdir parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,10 @@
 # config_hash = undef (Default)
 #   Hash with config options to set in sysconfig/jenkins defaults/jenkins
 #
+# sysconfdir = (/etc/sysconfig/jenkins /etc/default/jenkins)
+#   Controls the path to the "sysconfig" file that stores jenkins service
+#   startup variables
+#
 # manage_datadirs = true (default)
 #   true if this module should manage the local state dir, plugins dir and jobs dir
 #
@@ -201,6 +205,7 @@ class jenkins(
   $cli_try_sleep      = $jenkins::params::cli_try_sleep,
   $port               = $jenkins::params::port,
   $libdir             = $jenkins::params::libdir,
+  $sysconfdir         = $jenkins::params::sysconfdir,
   $manage_datadirs    = $jenkins::params::manage_datadirs,
   $localstatedir      = $::jenkins::params::localstatedir,
   $executors          = undef,
@@ -238,6 +243,7 @@ class jenkins(
   validate_integer($cli_try_sleep)
   validate_integer($port)
   validate_absolute_path($libdir)
+  validate_absolute_path($sysconfdir)
   validate_bool($manage_datadirs)
   validate_absolute_path($localstatedir)
   if $executors { validate_integer($executors) }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,6 +35,7 @@ class jenkins::params {
       $libdir           = '/usr/share/jenkins'
       $package_provider = 'dpkg'
       $service_provider = undef
+      $sysconfdir       = '/etc/default'
       $config_hash_defaults = {
         'JAVA_ARGS' => { value => $_java_args },
         'AJP_PORT'  => { value => '-1' },
@@ -58,15 +59,17 @@ class jenkins::params {
           $service_provider = undef
         }
       }
+      $sysconfdir           = '/etc/sysconfig'
       $config_hash_defaults = {
         'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
         'JENKINS_AJP_PORT'     => { value => '-1' },
       }
     }
     default: {
-      $libdir           = '/usr/lib/jenkins'
-      $package_provider = undef
-      $service_provider = undef
+      $libdir               = '/usr/lib/jenkins'
+      $package_provider     = undef
+      $service_provider     = undef
+      $sysconfdir           = '/etc/sysconfig'
       $config_hash_defaults = {
         'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
         'JENKINS_AJP_PORT'     => { value => '-1' },

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -207,7 +207,7 @@ class jenkins::slave (
   # customizations based on the OS family
   case $::osfamily {
     'Debian': {
-      $defaults_location = '/etc/default'
+      $defaults_location = $::jenkins::params::sysconfdir
 
       ensure_packages(['daemon'])
       Package['daemon'] -> Service['jenkins-slave']
@@ -216,7 +216,7 @@ class jenkins::slave (
       $defaults_location = $slave_home
     }
     default: {
-      $defaults_location = '/etc/sysconfig'
+      $defaults_location = $::jenkins::params::sysconfdir
     }
   }
 

--- a/manifests/sysconfig.pp
+++ b/manifests/sysconfig.pp
@@ -5,15 +5,8 @@ define jenkins::sysconfig(
 ) {
   validate_string($value)
 
-  $path = $::osfamily ? {
-    'RedHat' => '/etc/sysconfig',
-    'Suse'   => '/etc/sysconfig',
-    'Debian' => '/etc/default',
-    default  => fail( "Unsupported OSFamily ${::osfamily}" )
-  }
-
   file_line { "Jenkins sysconfig setting ${name}":
-    path   => "${path}/jenkins",
+    path   => "${::jenkins::sysconfdir}/jenkins",
     line   => "${name}=\"${value}\"",
     match  => "^${name}=",
     notify => Service['jenkins'],

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -27,6 +27,11 @@ describe 'jenkins class' do
       it { should be_file }
     end
 
+    describe file("#{$sysconfdir}/jenkins") do
+      it { should be_file }
+      it { should contain 'JENKINS_AJP_PORT="-1"' }
+    end
+
     describe service('jenkins') do
       it { should be_running }
       it { should be_enabled }

--- a/spec/acceptance/slave_spec.rb
+++ b/spec/acceptance/slave_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper_acceptance'
+
+describe 'jenkins::slave class' do
+  include_context 'jenkins'
+
+  context 'default parameters' do
+    it 'should work with no errors' do
+      pp = <<-EOS
+        include ::jenkins::slave
+      EOS
+
+      # Run it twice and test for idempotency
+      apply(pp, :catch_failures => true)
+      apply(pp, :catch_changes => true)
+    end
+
+    describe file('/etc/init.d/jenkins-slave') do
+      it { should be_file }
+      it { should be_mode 755 }
+    end
+
+    describe file("#{$sysconfdir}/jenkins-slave") do
+      it { should be_file }
+      it { should be_mode 600 }
+    end
+
+    describe file('/home/jenkins-slave/swarm-client-2.0-jar-with-dependencies.jar') do
+      it { should be_file }
+      it { should be_mode 644 }
+    end
+
+    describe service('jenkins-slave') do
+      it { should be_running }
+      it { should be_enabled }
+    end
+  end # default parameters
+end

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -70,6 +70,28 @@ describe 'jenkins', :type => :module do
       it { expect { should raise_error(Puppet::Error) } }
     end
 
+    describe 'sysconfdir =>' do
+      context '/foo/bar' do
+        let(:params) {{ :sysconfdir => '/foo/bar' }}
+        it do
+          should contain_file_line('Jenkins sysconfig setting JENKINS_JAVA_OPTIONS')
+            .with_path('/foo/bar/jenkins')
+        end
+      end
+
+      context '../bar' do
+        let(:params) {{ :sysconfdir => '../bar' }}
+        it { should raise_error(Puppet::Error, /is not an absolute path/) }
+      end
+
+      context '(default)' do
+        it do
+          should contain_file_line('Jenkins sysconfig setting JENKINS_JAVA_OPTIONS')
+            .with_path('/etc/sysconfig/jenkins')
+        end
+      end
+    end
+
     describe 'manage_datadirs =>' do
       context 'false' do
         let(:params) {{ :manage_datadirs => false }}

--- a/spec/defines/jenkins_sysconfig_spec.rb
+++ b/spec/defines/jenkins_sysconfig_spec.rb
@@ -1,10 +1,46 @@
 require 'spec_helper'
 
 describe 'jenkins::sysconfig' do
+  let(:pre_condition) { 'include ::jenkins' }
+
   let(:title) { 'myprop' }
-  let(:facts) { { :osfamily => 'RedHat' } }
   let(:params) { { 'value' => 'myvalue' } }
 
-  it { should contain_file_line('Jenkins sysconfig setting myprop') }
+  describe 'on RedHat' do
+    let(:facts) do
+      {
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => 'CentOS',
+        :operatingsystemrelease    => '7.2',
+        :operatingsystemmajrelease => '7',
+      }
+    end
 
+    it do
+      should contain_file_line('Jenkins sysconfig setting myprop').with(
+        :path  => '/etc/sysconfig/jenkins',
+        :line  => 'myprop="myvalue"',
+        :match => '^myprop=',
+      ).that_notifies('Service[jenkins]')
+    end
+  end # on RedHat
+
+  describe 'on Debian' do
+    let(:facts) do
+      {
+        :osfamily        => 'Debian',
+        :operatingsystem => 'Debian',
+        :lsbdistcodename => 'squeeze',
+        :lsbdistid       => 'bebian'
+      }
+    end
+
+    it do
+      should contain_file_line('Jenkins sysconfig setting myprop').with(
+        :path  => '/etc/default/jenkins',
+        :line  => 'myprop="myvalue"',
+        :match => '^myprop=',
+      ).that_notifies('Service[jenkins]')
+    end
+  end # on Debian
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -44,6 +44,12 @@ shared_context 'jenkins' do
             when 'Debian'
               '/usr/share/jenkins'
             end
+  $sysconfdir = case fact 'osfamily'
+                when 'RedHat'
+                  '/etc/sysconfig'
+                when 'Debian'
+                  '/etc/default'
+                end
 
   let(:libdir) { $libdir }
 


### PR DESCRIPTION
Controls the path to the "sysconfig" file that stores jenkins service
startup variables