### PR TITLE
fix slave systemd support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,5 +10,6 @@ fixtures:
     zypprepo: "https://github.com/deadpoint/puppet-zypprepo.git"
     archive: "https://github.com/voxpupuli/puppet-archive.git"
     systemd: "https://github.com/camptocamp/puppet-systemd"
+    transition: "https://github.com/puppetlabs/puppetlabs-transition"
   symlinks:
     "jenkins": "#{source_dir}"

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -231,8 +231,9 @@ class jenkins::slave (
       # lint:ignore:quoted_booleans
       if $::systemd == 'true' {
         include ::systemd
-        file { "${::jenkins::params::libdir}/jenkins-slave-run":
+        file { "${slave_home}/jenkins-slave-run":
           content => template("${module_name}/jenkins-slave-run.erb"),
+          owner   => $slave_user,
           mode    => '0700',
           notify  => Service['jenkins-slave'],
         }

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -222,10 +222,11 @@ class jenkins::slave (
 
   case $::kernel {
     'Linux': {
-      $service_name   = 'jenkins-slave'
-      $defaults_user  = 'root'
-      $defaults_group = 'root'
+      $service_name     = 'jenkins-slave'
+      $defaults_user    = 'root'
+      $defaults_group   = 'root'
       $manage_user_home = true
+      $sysv_init        = '/etc/init.d/jenkins-slave'
 
       if $::systemd {
         include ::systemd
@@ -235,15 +236,33 @@ class jenkins::slave (
           mode    => '0700',
           notify  => Service['jenkins-slave'],
         }
-        file { '/etc/init.d/jenkins-slave':
-          ensure => 'absent',
+        transition { 'stop jenkins-slave service':
+          resource   => Service['jenkins-slave'],
+          attributes => {
+            # lint:ignore:ensure_first_param
+            ensure => stopped
+            # lint:endignore
+          },
+          prior_to   => [
+            File[$sysv_init],
+          ],
         }
+        # transition can not set a prior_to on
+        # Systemd::Unit_file['jenkins-slave.service'] as it is not a native
+        # type so we must us the sysv init script as a proxy
+        file { $sysv_init:
+          ensure                  => 'absent',
+          # XXX if this is not set, the seluser property will claim is it out
+          # of sync and the transition resource will always fire.  It isn't
+          # clear if this is a bug or a feature of the file resource.
+          selinux_ignore_defaults => true,
+        } ->
         systemd::unit_file { 'jenkins-slave.service':
           content => template("${module_name}/jenkins-slave.service.erb"),
           notify  => Service['jenkins-slave'],
         }
       } else {
-        file { '/etc/init.d/jenkins-slave':
+        file { $sysv_init:
           ensure => 'file',
           mode   => '0755',
           owner  => 'root',

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -227,9 +227,7 @@ class jenkins::slave (
       $defaults_group = 'root'
       $manage_user_home = true
 
-      # Disable lint checking below because we actually do need a string here
-      # lint:ignore:quoted_booleans
-      if $::systemd == 'true' {
+      if $::systemd {
         include ::systemd
         file { "${slave_home}/jenkins-slave-run":
           content => template("${module_name}/jenkins-slave-run.erb"),
@@ -254,7 +252,6 @@ class jenkins::slave (
           notify => Service['jenkins-slave'],
         }
       }
-      # lint:endignore
     }
     'Darwin': {
       $service_name     = 'org.jenkins-ci.slave.jnlp'

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,7 @@
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "puppet/archive", "version_requirement": ">= 0.4.8" },
-    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0" }
+    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0" },
+    { "name": "puppetlabs/transition", "version_requirement": ">= 0.1.0 < 1.0.0" }
   ]
 }

--- a/spec/acceptance/slave_spec.rb
+++ b/spec/acceptance/slave_spec.rb
@@ -14,7 +14,7 @@ describe 'jenkins::slave class' do
       apply(pp, :catch_changes => true)
     end
 
-    if fact('systemd') == 'true'
+    if fact('systemd')
       describe file('/lib/systemd/system/jenkins-slave.service') do
         it { should be_file }
         it { should contain 'ExecStart=/home/jenkins-slave/jenkins-slave-run' }

--- a/spec/acceptance/slave_spec.rb
+++ b/spec/acceptance/slave_spec.rb
@@ -15,7 +15,7 @@ describe 'jenkins::slave class' do
     end
 
     if fact('systemd')
-      describe file('/lib/systemd/system/jenkins-slave.service') do
+      describe file('/etc/systemd/system/jenkins-slave.service') do
         it { should be_file }
         it { should contain 'ExecStart=/home/jenkins-slave/jenkins-slave-run' }
       end
@@ -26,7 +26,7 @@ describe 'jenkins::slave class' do
         it { should be_running.under('systemd') }
       end
     else
-      describe file('/lib/systemd/system/jenkins-slave.service') do
+      describe file('/etc/systemd/system/jenkins-slave.service') do
         it { should_not exist }
       end
       describe file('/etc/init.d/jenkins-slave') do

--- a/spec/acceptance/slave_spec.rb
+++ b/spec/acceptance/slave_spec.rb
@@ -17,7 +17,7 @@ describe 'jenkins::slave class' do
     if fact('systemd') == 'true'
       describe file('/lib/systemd/system/jenkins-slave.service') do
         it { should be_file }
-        it { should contain "ExecStart=#{$libdir}/jenkins-slave-run" }
+        it { should contain 'ExecStart=/home/jenkins-slave/jenkins-slave-run' }
       end
       describe file('/etc/init.d/jenkins-slave') do
         it { should_not exist }

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -226,11 +226,11 @@ describe 'jenkins::slave' do
           :operatingsystemrelease    => '7.2',
           :operatingsystemmajrelease => '7',
           :kernel                    => 'Linux',
-          :systemd                   => 'true'
+          :systemd                   => true
         }
       end
       let(:slave_service_file) { '/etc/systemd/system/jenkins-slave.service' }
-      let(:slave_startup_script) { '/usr/lib/jenkins/jenkins-slave-run' }
+      let(:slave_startup_script) { '/home/jenkins-slave/jenkins-slave-run' }
       let(:slave_sysv_file) { '/etc/init.d/jenkins-slave' }
       it_behaves_like 'a jenkins::slave catalog'
       it { should contain_file(slave_startup_script) }

--- a/spec/classes/jenkins_slave_spec.rb
+++ b/spec/classes/jenkins_slave_spec.rb
@@ -184,7 +184,7 @@ describe 'jenkins::slave' do
         :operatingsystemrelease    => '6.7',
         :operatingsystemmajrelease => '6',
         :kernel                    => 'Linux',
-        :systemd                   => 'false'
+        :systemd                   => false
       }
     end
     let(:slave_runtime_file) { '/etc/sysconfig/jenkins-slave' }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -33,6 +33,7 @@ RSpec.configure do |c|
       on host, puppet('module install darin-zypprepo'), { :acceptable_exit_codes => [0] }
       on host, puppet('module install puppet-archive'), { :acceptable_exit_codes => [0] }
       on host, puppet('module install camptocamp-systemd'), { :acceptable_exit_codes => [0] }
+      on host, puppet('module install puppetlabs-transition'), { :acceptable_exit_codes => [0] }
     end
   end
 end

--- a/templates/jenkins-slave.service.erb
+++ b/templates/jenkins-slave.service.erb
@@ -11,7 +11,7 @@ Type=simple
 # the run/wrapper script.  This [sadly] requires that the run script be run as
 # root so that it has the effective permission to read this file.
 #
-ExecStart=<%= scope['jenkins::params::libdir'] %>/jenkins-slave-run
+ExecStart=<%= scope['jenkins::slave::slave_home'] %>/jenkins-slave-run
 Restart=always
 RestartSec=60
 StartLimitInterval=0


### PR DESCRIPTION
Due to fact quoting shenanigans, systemd support wasn't working. Due to the same logic error in the acceptance tests, systemd wasn't being properly covered either.

Resolves #663 