### PR TITLE
add jenkins::default_plugins param

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,7 @@ class jenkins::config {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  ensure_resource('jenkins::plugin', $::jenkins::params::default_plugins)
+  ensure_resource('jenkins::plugin', $::jenkins::default_plugins)
 
   $config_hash = merge(
     $::jenkins::params::config_hash_defaults,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -291,7 +291,7 @@ class jenkins(
     include jenkins::service
     validate_array($default_plugins)
     if empty($default_plugins){
-      notice(sprintf("INFO: make sure you install the following plugins with your code using this module: %s",join($::jenkins::params::default_plugins,',')))
+      notice(sprintf('INFO: make sure you install the following plugins with your code using this module: %s',join($::jenkins::params::default_plugins,',')))
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -176,6 +176,9 @@
 #
 # group = 'jenkins' (default)
 #
+# default_plugins = [ 'credentials' ] (default)
+#   List of default plugins to manage, overwrite if you manage
+#   all plugins
 #
 class jenkins(
   $version            = $jenkins::params::version,
@@ -214,6 +217,7 @@ class jenkins(
   $user               = $::jenkins::params::user,
   $manage_group       = $::jenkins::params::manage_group,
   $group              = $::jenkins::params::group,
+  $default_plugins    = $::jenkins::params::default_plugins,
 ) inherits jenkins::params {
 
   validate_string($version)
@@ -285,6 +289,10 @@ class jenkins(
 
   if $manage_service {
     include jenkins::service
+    validate_array($default_plugins)
+    if empty($default_plugins){
+      notice(sprintf("INFO: make sure you install the following plugins with your code using this module: %s",join($::jenkins::params::default_plugins,',')))
+    }
   }
 
   if defined('::firewall') {

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -328,5 +328,14 @@ describe 'jenkins', :type => :module do
         end
       end
     end # manages state dirs
+
+    describe 'with default plugins' do
+      it { should contain_jenkins__plugin 'credentials' }
+    end
+
+    describe 'with default plugins override' do
+      let (:params) {{ :default_plugins => [] }}
+      it { should_not contain_jenkins__plugin 'credentials' }
+    end
   end
 end


### PR DESCRIPTION
mash up of #646 and #675

Allows the version of the credentials plugin to be specified via plugin_hash by removing it from the default_plugins list.  Eg.  (Per @jeffmccune)

    jenkins::default_plugins: []
    jenkins::plugin_hash:
      credentials:
        version: 2.1.5
        digest_string: 7db002e7b053f863e2ce96fb58abb98a9c01b09c
        digest_type: sha1

closes #646
closes #675
resolves #665