### PR TITLE
restart jenkins master after purging plugins

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,7 +45,8 @@ class jenkins::config {
     true    => merge($dir_params, {
       purge   => true,
       recurse => true,
-      force   => true
+      force   => true,
+      notify  => Service['jenkins'],
     }),
     default => $dir_params,
   }

--- a/spec/classes/jenkins_spec.rb
+++ b/spec/classes/jenkins_spec.rb
@@ -358,7 +358,7 @@ describe 'jenkins', :type => :module do
             :purge   => true,
             :recurse => true,
             :force   => true,
-          )
+          ).that_notifies('Service[jenkins]')
         end
       end
 
@@ -368,6 +368,7 @@ describe 'jenkins', :type => :module do
             .without('purge')
             .without('recurse')
             .without('force')
+            .without('notify')
         end
       end
 


### PR DESCRIPTION
Without a restart, a jenkins fault may occur when listing installed
plugins as the plugin may still be loaded but the persistent files would
be absent from disk.