### PR TITLE
Let bash expand Java arguments

### DIFF
--- a/templates/jenkins-slave-run.erb
+++ b/templates/jenkins-slave-run.erb
@@ -14,7 +14,7 @@ fail() {
 SLAVE_ARGS=()
 
 [[ -n "$JAVA_ARGS" ]] &&
-  SLAVE_ARGS+=("$JAVA_ARGS")
+  SLAVE_ARGS+=($JAVA_ARGS)
 
 SLAVE_ARGS+=(-jar "$JENKINS_SLAVE_JAR")
 


### PR DESCRIPTION
When multiple $JAVA_ARGS are passed in quotation marks, bash passes entire string as a single argument to java command. To make sure options are digested one by one, java options should not be enclosed in quotes.