### PR TITLE
Debian repo deprecation warnings

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -17,10 +17,10 @@ class jenkins::repo::debian
       key      => {
         id     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
         source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      }
+      },
       include  => {
         src    => false,
-      }
+      },
     }
   }
   else {
@@ -31,10 +31,10 @@ class jenkins::repo::debian
       key      => {
         id     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
         source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      }
+      },
       include  => {
         src    => false,
-      }
+      },
     }
   }
 

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -14,9 +14,13 @@ class jenkins::repo::debian
       location    => 'http://pkg.jenkins-ci.org/debian-stable',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      key         => {
+        id        => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        source    => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      }
+      include     => {
+        src       => false,
+      }
     }
   }
   else {
@@ -24,9 +28,13 @@ class jenkins::repo::debian
       location    => 'http://pkg.jenkins-ci.org/debian',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
-      include_src => false,
+      key         => {
+        id        => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        source    => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      }
+      include     => {
+        src       => false,
+      }
     }
   }
 

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -11,29 +11,29 @@ class jenkins::repo::debian
 
   if $::jenkins::lts  {
     apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian-stable',
-      release     => 'binary/',
-      repos       => '',
-      key         => {
-        id        => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-        source    => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      location => 'http://pkg.jenkins-ci.org/debian-stable',
+      release  => 'binary/',
+      repos    => '',
+      key      => {
+        id     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
       }
-      include     => {
-        src       => false,
+      include  => {
+        src    => false,
       }
     }
   }
   else {
     apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian',
-      release     => 'binary/',
-      repos       => '',
-      key         => {
-        id        => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-        source    => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      location => 'http://pkg.jenkins-ci.org/debian',
+      release  => 'binary/',
+      repos    => '',
+      key      => {
+        id     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
+        source => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
       }
-      include     => {
-        src       => false,
+      include  => {
+        src    => false,
       }
     }
   }


### PR DESCRIPTION
The apt module changed the required format in version 2.1, we now get warnings about the old parameters. This merge just updates the repo debian class to bring it inline with the apt module requirements