### PR TITLE
feature/remove jenkins plugin before downloading it

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -174,6 +174,9 @@ define jenkins::plugin(
       $checksum_type   = undef
     }
 
+    exec{"force ${plugin}-${version}":
+      command => "/bin/rm -rf ${::jenkins::plugin_dir}/${plugin}"
+    }->
     archive { $plugin:
       source          => $download_url,
       path            => "${::jenkins::plugin_dir}/${plugin}",

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -176,8 +176,8 @@ define jenkins::plugin(
 
     exec{"force ${plugin}-${version}":
       command => "/bin/rm -rf ${::jenkins::plugin_dir}/${plugin}"
-    }->
-    archive { $plugin:
+    }
+    -> archive { $plugin:
       source          => $download_url,
       path            => "${::jenkins::plugin_dir}/${plugin}",
       checksum_verify => $checksum_verify,

--- a/spec/acceptance/nodesets/centos-7-docker.Dockerfile
+++ b/spec/acceptance/nodesets/centos-7-docker.Dockerfile
@@ -4,7 +4,7 @@ ENV container docker
 
 # beaker default behavior
 RUN yum clean all
-RUN yum install -y sudo openssh-server openssh-clients curl ntpdate
+RUN yum install -y sudo openssh-server openssh-clients curl ntpdate unzip
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
 RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
 RUN mkdir -p /var/run/sshd

--- a/spec/acceptance/plugin_spec.rb
+++ b/spec/acceptance/plugin_spec.rb
@@ -55,6 +55,46 @@ describe 'jenkins class', :order => :defined do
     it_behaves_like 'has_git_plugin'
   end
 
+
+  describe 'plugin downgrade' do
+    before(:all) do
+      pp = <<-EOS
+      class {'jenkins':
+        cli_remoting_free => true,
+        purge_plugins     => true,
+      }
+
+      jenkins::plugin {'git-plugin':
+        name    => 'git',
+        version => '2.3.4',
+      }
+      EOS
+      apply2(pp)
+    end
+
+    context 'downgrade' do
+      git_version =
+      it 'should downgrade git version' do
+        pp = <<-EOS
+        class {'jenkins':
+          cli_remoting_free => true,
+          purge_plugins     => true,
+        }
+
+        jenkins::plugin {'git-plugin':
+          name    => 'git',
+          version => '1.0',
+        }
+        EOS
+        apply2(pp)
+        # Find the version of the installed git plugin
+        git_version = shell("unzip -p #{$pdir}/git.hpi META-INF/MANIFEST.MF | sed 's/Plugin-Version: \\\(.*\\\)/\\1/;tx;d;:x'").stdout.strip
+        git_version.should eq('1.0')
+      end
+      it_behaves_like 'has_git_plugin'
+    end
+  end
+
   describe 'plugin purging' do
     context 'true' do
       include_context 'plugin_test_files'


### PR DESCRIPTION
## Why ?
This Pull request assess a problem when upgrading jenkins plugins : The module correctly check if the version is correct and if not, runs into the installation process.
However. as puppet-archive is used and is idempotent, it does not change the version of the so called plugin if it is already installed.

## How ?
The pull request is fairly simple : remove the previous file using exec.
If we use the file puppet method, 
```
file{"${::jenkins::plugin_dir}/${plugin}":
    ensure => absent
}
 
```
the file is already taken care of, and this leads to an error.
