### PR TITLE
Initial FreeBSD support

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -31,7 +31,7 @@ class jenkins::cli {
 
   exec { 'jenkins-cli' :
     command => "${extract_jar} && ${move_jar} && ${remove_dir}",
-    path    => ['/bin', '/usr/bin'],
+    path    => ['/bin', '/usr/bin', '/usr/local/bin'],
     cwd     => '/tmp',
     creates => $jar,
     require => Service['jenkins'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,16 @@ class jenkins::params {
         'AJP_PORT'  => { value => '-1' },
       }
     }
+    'FreeBSD': {
+      $libdir           = '/usr/local/share/jenkins'
+      $package_provider = 'pkgng'
+      $service_provider = undef
+      $sysconfdir       = '/usr/local/etc/default'
+      $config_hash_defaults = {
+        'JAVA_ARGS' => { value => $_java_args },
+        'AJP_PORT'  => { value => '-1' },
+      }
+    }
     'RedHat': {
       $libdir           = '/usr/lib/jenkins'
       $package_provider = 'rpm'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -27,6 +27,9 @@ class jenkins::repo {
           Anchor['jenkins::repo::end']
       }
 
+      'FreeBSD': {
+      }
+
       'Suse' : {
         class { '::jenkins::repo::suse': }
         Anchor['jenkins::repo::begin'] ->


### PR DESCRIPTION
I want to improve module and add support for FreeBSD platform. I plan to implement it in small commits 
chunk/steps and this is the first of them. All changes are tested on FreeBSD 11/12 (aka HEAD)

- add cases for FreeBSD-specific params
- expand exec path to /usr/local/bin which is the default path for 3rd-party software on FreeBSD (and probaly other: HP-UX, Solaris)
