### PR TITLE
Added legacy functionality when using the `-s` flag in the jenkins cli

### DIFF
--- a/lib/puppet_x/jenkins/provider/cli.rb
+++ b/lib/puppet_x/jenkins/provider/cli.rb
@@ -163,7 +163,7 @@ class PuppetX::Jenkins::Provider::Cli < Puppet::Provider
 
     auth_cmd = nil
     unless ssh_private_key.nil?
-      auth_cmd = base_cmd + ['-i', ssh_private_key] + [command]
+      auth_cmd = base_cmd + ['-remoting -i', ssh_private_key] + [command]
       auth_cmd.flatten!
     end
 

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -48,7 +48,7 @@ class jenkins::cli {
 
   # Provide the -i flag if specified by the user.
   if $::jenkins::cli_ssh_keyfile {
-    $auth_arg = "-i ${::jenkins::cli_ssh_keyfile}"
+    $auth_arg = "-remoting -i ${::jenkins::cli_ssh_keyfile}"
   } else {
     $auth_arg = undef
   }

--- a/manifests/cli_helper.pp
+++ b/manifests/cli_helper.pp
@@ -37,7 +37,7 @@ class jenkins::cli_helper (
 
   # Provide the -i flag if specified by the user.
   if $ssh_keyfile {
-    $auth_arg = "-i ${ssh_keyfile}"
+    $auth_arg = "-remoting -i ${ssh_keyfile}"
   } else {
     $auth_arg = undef
   }


### PR DESCRIPTION
Latest jenkins release is not accepting anymore the `-s` flag to use the cli as admin with an ssh key using the http api, we have to add the `-remoting` option to use this functionality.