### PR TITLE
(documentation) [ci skip]: minor typo affecting markdown rendering of jenkins_job

### DIFF
--- a/NATIVE_TYPES_AND_PROVIDERS.md
+++ b/NATIVE_TYPES_AND_PROVIDERS.md
@@ -301,6 +301,7 @@ jenkins_credentials { '002224bd-60cb-49f3-a314-d0f73f82233d':
   token       => '{PRIVATE TOKEN}',
   url         => 'https://my-phabricator-repo.com',
 }
+```
 
 ### `jenkins_job`
 


### PR DESCRIPTION

Small typo in native types and providers docs prevented `jenkins_job` being readable...