### PR TITLE
Restore archive require

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -186,14 +186,17 @@ define jenkins::plugin(
       require         => File[$::jenkins::plugin_dir],
       notify          => Service['jenkins'],
     }
+    $archive_require = Archive[$plugin]
+  } else {
+    $archive_require = undef
   }
 
   file { "${::jenkins::plugin_dir}/${plugin}" :
-    owner  => $::jenkins::user,
-    group  => $::jenkins::group,
-    mode   => '0644',
-    require => Archive[$plugin],
-    before => Service['jenkins'],
+    owner   => $::jenkins::user,
+    group   => $::jenkins::group,
+    mode    => '0644',
+    require => $archive_require,
+    before  => Service['jenkins'],
   }
 
   if $manage_config {

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -192,6 +192,7 @@ define jenkins::plugin(
     owner  => $::jenkins::user,
     group  => $::jenkins::group,
     mode   => '0644',
+    require => Archive[$plugin],
     before => Service['jenkins'],
   }
 


### PR DESCRIPTION
Without this change, our integration testing fails on the idempotence check: the plugin download files aren't set to the correct ownerships on the initial run, and are restored on the second run:

```
Notice: Compiled catalog for 1a6e30201881 in environment production in 4.64 seconds
Info: Applying configuration version '1495173361'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[git]/Jenkins::Plugin[git]/File[/var/lib/jenkins/plugins/git.hpi]/owner: owner changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[git]/Jenkins::Plugin[git]/File[/var/lib/jenkins/plugins/git.hpi]/group: group changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[github]/Jenkins::Plugin[github]/File[/var/lib/jenkins/plugins/github.hpi]/owner: owner changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[github]/Jenkins::Plugin[github]/File[/var/lib/jenkins/plugins/github.hpi]/group: group changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[build-flow-plugin]/Jenkins::Plugin[build-flow-plugin]/File[/var/lib/jenkins/plugins/build-flow-plugin.hpi]/owner: owner changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[build-flow-plugin]/Jenkins::Plugin[build-flow-plugin]/File[/var/lib/jenkins/plugins/build-flow-plugin.hpi]/group: group changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[handlebars]/Jenkins::Plugin[handlebars]/File[/var/lib/jenkins/plugins/handlebars.hpi]/owner: owner changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[handlebars]/Jenkins::Plugin[handlebars]/File[/var/lib/jenkins/plugins/handlebars.hpi]/group: group changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[run-condition]/Jenkins::Plugin[run-condition]/File[/var/lib/jenkins/plugins/run-condition.hpi]/owner: owner changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[run-condition]/Jenkins::Plugin[run-condition]/File[/var/lib/jenkins/plugins/run-condition.hpi]/group: group changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[rake]/Jenkins::Plugin[rake]/File[/var/lib/jenkins/plugins/rake.hpi]/owner: owner changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[rake]/Jenkins::Plugin[rake]/File[/var/lib/jenkins/plugins/rake.hpi]/group: group changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[ansicolor]/Jenkins::Plugin[ansicolor]/File[/var/lib/jenkins/plugins/ansicolor.hpi]/owner: owner changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[ansicolor]/Jenkins::Plugin[ansicolor]/File[/var/lib/jenkins/plugins/ansicolor.hpi]/group: group changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[workflow-job]/Jenkins::Plugin[workflow-job]/File[/var/lib/jenkins/plugins/workflow-job.hpi]/owner: owner changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[workflow-job]/Jenkins::Plugin[workflow-job]/File[/var/lib/jenkins/plugins/workflow-job.hpi]/group: group changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[copyartifact]/Jenkins::Plugin[copyartifact]/File[/var/lib/jenkins/plugins/copyartifact.hpi]/owner: owner changed 'root' to 'jenkins'
Notice: /Stage[main]/Profile_jenkins::Master/Profile_jenkins::Plugin[copyartifact]/Jenkins::Plugin[copyartifact]/File[/var/lib/jenkins/plugins/copyartifact.hpi]/group: group changed 'root' to 'jenkins'
```