### PR TITLE
Switch repositories to HTTPs to take advantage of end-to-end TLS

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -9,9 +9,13 @@ class jenkins::repo::debian
   include ::stdlib
   include ::apt
 
+  $pkg_host = 'https://pkg.jenkins.io'
+
+  ensure_packages(['apt-transport-https'])
+
   if $::jenkins::lts  {
     apt::source { 'jenkins':
-      location => 'http://pkg.jenkins-ci.org/debian-stable',
+      location => "${pkg_host}/debian-stable",
       release  => 'binary/',
       repos    => '',
       include  => {
@@ -19,13 +23,14 @@ class jenkins::repo::debian
       },
       key      => {
         'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-        'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+        'source' => "${pkg_host}/debian/jenkins-ci.org.key",
       },
+      require  => Package['apt-transport-https'],
     }
   }
   else {
     apt::source { 'jenkins':
-      location => 'http://pkg.jenkins-ci.org/debian',
+      location => "${pkg_host}/debian",
       release  => 'binary/',
       repos    => '',
       include  => {
@@ -33,8 +38,9 @@ class jenkins::repo::debian
       },
       key      => {
         'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-        'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+        'source' => "${pkg_host}/debian/jenkins-ci.org.key",
       },
+      require  => Package['apt-transport-https'],
     }
   }
 

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -12,9 +12,9 @@ class jenkins::repo::el
   if $::jenkins::lts  {
     yumrepo {'jenkins':
       descr    => 'Jenkins',
-      baseurl  => 'http://pkg.jenkins-ci.org/redhat-stable/',
+      baseurl  => 'https://pkg.jenkins.io/redhat-stable/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
+      gpgkey   => 'https://pkg.jenkins.io/redhat/jenkins-ci.org.key',
       enabled  => 1,
       proxy    => $repo_proxy,
     }
@@ -23,9 +23,9 @@ class jenkins::repo::el
   else {
     yumrepo {'jenkins':
       descr    => 'Jenkins',
-      baseurl  => 'http://pkg.jenkins-ci.org/redhat/',
+      baseurl  => 'https://pkg.jenkins.io/redhat/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
+      gpgkey   => 'https://pkg.jenkins.io/redhat/jenkins-ci.org.key',
       enabled  => 1,
       proxy    => $repo_proxy,
     }

--- a/manifests/repo/suse.pp
+++ b/manifests/repo/suse.pp
@@ -10,16 +10,16 @@ class jenkins::repo::suse
   if $::jenkins::lts {
     zypprepo {'jenkins':
       descr    => 'Jenkins',
-      baseurl  => 'http://pkg.jenkins-ci.org/opensuse-stable/',
+      baseurl  => 'https://pkg.jenkins.io/opensuse-stable/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
+      gpgkey   => 'https://pkg.jenkins.io/redhat/jenkins-ci.org.key',
     }
   } else {
     zypprepo {'jenkins':
       descr    => 'Jenkins',
-      baseurl  => 'http://pkg.jenkins-ci.org/opensuse/',
+      baseurl  => 'https://pkg.jenkins.io/opensuse/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
+      gpgkey   => 'https://pkg.jenkins.io/redhat/jenkins-ci.org.key',
     }
   }
 }

--- a/spec/classes/jenkins_repo_debian_spec.rb
+++ b/spec/classes/jenkins_repo_debian_spec.rb
@@ -18,19 +18,19 @@ describe 'jenkins', :type => :module do
 
     describe 'default' do
       it_behaves_like 'an apt catalog'
-      it { should contain_apt__source('jenkins').with_location('http://pkg.jenkins-ci.org/debian-stable') }
+      it { should contain_apt__source('jenkins').with_location('https://pkg.jenkins.io/debian-stable') }
     end
 
     describe 'lts = true' do
       let(:params) { { :lts => true } }
       it_behaves_like 'an apt catalog'
-      it { should contain_apt__source('jenkins').with_location('http://pkg.jenkins-ci.org/debian-stable') }
+      it { should contain_apt__source('jenkins').with_location('https://pkg.jenkins.io/debian-stable') }
     end
 
     describe 'lts = false' do
       let(:params) { { :lts => false } }
       it_behaves_like 'an apt catalog'
-      it { should contain_apt__source('jenkins').with_location('http://pkg.jenkins-ci.org/debian') }
+      it { should contain_apt__source('jenkins').with_location('https://pkg.jenkins.io/debian') }
     end
   end
 end

--- a/spec/classes/jenkins_repo_el_spec.rb
+++ b/spec/classes/jenkins_repo_el_spec.rb
@@ -13,20 +13,20 @@ describe 'jenkins', :type => :module do
 
   context 'repo::el' do
     describe 'default' do
-      it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat-stable/') }
+      it { should contain_yumrepo('jenkins').with_baseurl('https://pkg.jenkins.io/redhat-stable/') }
       it { should contain_yumrepo('jenkins').with_proxy(nil) }
     end
 
     describe 'lts = true' do
       let(:params) { { :lts => true } }
-      it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat-stable/') }
+      it { should contain_yumrepo('jenkins').with_baseurl('https://pkg.jenkins.io/redhat-stable/') }
       it { should contain_yumrepo('jenkins').with_proxy(nil) }
     end
 
     describe 'lts = false' do
       let(:params) { { :lts => false } }
       it { should contain_yumrepo('jenkins').with_proxy(nil) }
-      it { should contain_yumrepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/redhat/') }
+      it { should contain_yumrepo('jenkins').with_baseurl('https://pkg.jenkins.io/redhat/') }
     end
 
     describe 'repo_proxy is set' do

--- a/spec/classes/jenkins_repo_suse_spec.rb
+++ b/spec/classes/jenkins_repo_suse_spec.rb
@@ -6,17 +6,17 @@ describe 'jenkins', :type => :module do
 
   context 'repo::suse' do
     describe 'default' do
-      it { should contain_zypprepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/opensuse-stable/') }
+      it { should contain_zypprepo('jenkins').with_baseurl('https://pkg.jenkins.io/opensuse-stable/') }
     end
 
     describe 'lts = true' do
       let(:params) { { :lts => true } }
-      it { should contain_zypprepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/opensuse-stable/') }
+      it { should contain_zypprepo('jenkins').with_baseurl('https://pkg.jenkins.io/opensuse-stable/') }
     end
 
     describe 'lts = false' do
       let(:params) { { :lts => false } }
-      it { should contain_zypprepo('jenkins').with_baseurl('http://pkg.jenkins-ci.org/opensuse/') }
+      it { should contain_zypprepo('jenkins').with_baseurl('https://pkg.jenkins.io/opensuse/') }
     end
   end
 


### PR DESCRIPTION
A few months ago we enabled support for `https://pkg.jenkins.io` to serve packages over Azure storage, and therefore over TLS.

End-to-end, woot!