### PR TITLE
Add archlinux support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,8 +28,8 @@
 #   configure upstream jenkins package repos
 #
 #   ``false`` means do NOT configure the upstream jenkins package repo. This
-#   means you'll manage a repo manually outside this module.  This is for folks
-#   that use a custom repo, or the like.
+#   means you'll manage a repo manually outside this module. This can also be
+#   your distribution's repo.
 #
 # @param package_name
 #   Optionally override the package name

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -209,6 +209,7 @@
 #   Note that this value is used for CLI communication and firewall
 #   configuration.  It does not configure the port on which the jenkins service
 #   listens. (see config_hash)
+#
 # @param libdir
 #   Path to jenkins core files
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,8 +74,10 @@ class jenkins::params {
       $service_provider     = undef
       $sysconfdir           = '/etc/conf.d'
       $config_hash_defaults = {
-        'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
-        'JENKINS_AJP_PORT'     => { value => '-1' },
+        # Archlinux's jenkins package uses it's own variables
+        # which are not compatible with these.
+        #'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
+        #'JENKINS_AJP_PORT'     => { value => '-1' },
       }
     }
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,6 +66,16 @@ class jenkins::params {
         $service_provider = undef
       }
     }
+    'Archlinux': {
+      $libdir               = '/usr/share/java/jenkins/'
+      $package_provider     = 'pacman'
+      $service_provider     = undef
+      $sysconfdir           = '/etc/conf.d'
+      $config_hash_defaults = {
+        'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
+        'JENKINS_AJP_PORT'     => { value => '-1' },
+      }
+    }
     default: {
       $libdir               = '/usr/lib/jenkins'
       $package_provider     = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,6 @@
 class jenkins::params {
   $version               = 'installed'
   $lts                   = true
-  $repo                  = true
   $direct_download       = undef
   $service_enable        = true
   $service_ensure        = 'running'
@@ -34,18 +33,20 @@ class jenkins::params {
 
   case $::osfamily {
     'Debian': {
-      $libdir           = '/usr/share/jenkins'
-      $package_provider = 'dpkg'
-      $service_provider = undef
-      $sysconfdir       = '/etc/default'
+      $repo                 = true
+      $libdir               = '/usr/share/jenkins'
+      $package_provider     = 'dpkg'
+      $service_provider     = undef
+      $sysconfdir           = '/etc/default'
       $config_hash_defaults = {
         'JAVA_ARGS' => { value => $_java_args },
         'AJP_PORT'  => { value => '-1' },
       }
     }
     'RedHat': {
-      $libdir           = '/usr/lib/jenkins'
-      $package_provider = 'rpm'
+      $repo                 = true
+      $libdir               = '/usr/lib/jenkins'
+      $package_provider     = 'rpm'
       $sysconfdir           = '/etc/sysconfig'
       $config_hash_defaults = {
         'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
@@ -67,6 +68,7 @@ class jenkins::params {
       }
     }
     'Archlinux': {
+      $repo                 = false
       $libdir               = '/usr/share/java/jenkins/'
       $package_provider     = 'pacman'
       $service_provider     = undef
@@ -77,6 +79,7 @@ class jenkins::params {
       }
     }
     default: {
+      $repo                 = true
       $libdir               = '/usr/lib/jenkins'
       $package_provider     = undef
       $service_provider     = undef

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -45,12 +45,16 @@ shared_context 'jenkins' do
               '/usr/lib/jenkins'
             when 'Debian'
               '/usr/share/jenkins'
+            when 'Archlinux'
+              '/usr/share/java/jenkins/'
             end
   $sysconfdir = case fact 'osfamily'
                 when 'RedHat'
                   '/etc/sysconfig'
                 when 'Debian'
                   '/etc/default'
+                when 'Archlinux'
+                  '/etc/conf.d'
                 end
 
   let(:libdir) { $libdir }


### PR DESCRIPTION
Archlinux provides it's own jenkins package. To use this module with Archlinux one has to set 'repo = false'. params.pp has been expanded to use correct values.
___
EDIT 20170627:
- params.pp: define 'repo' per osfamily. Distributions for which an official repository exists at pkg.jenkins.io define 'repo = true'. To use Archlinux own jenkin's package, 'repo = false' is set.
- init.pp: When 'repo = false' is set, a custom repository or the distribution's package will be installed. Documentation of this parameter was adjusted to describe this use case.

This way the jenkins module can be used with Archlinux. Other distributions can be added the same way. Default behavior was not changed. 