### PR TITLE
Update Jenkins repo URLs

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -11,7 +11,7 @@ class jenkins::repo::debian
 
   if $::jenkins::lts  {
     apt::source { 'jenkins':
-      location => 'http://pkg.jenkins-ci.org/debian-stable',
+      location => 'http://pkg.jenkins.io/debian-stable',
       release  => 'binary/',
       repos    => '',
       include  => {
@@ -19,13 +19,13 @@ class jenkins::repo::debian
       },
       key      => {
         'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-        'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+        'source' => 'http://pkg.jenkins.io/debian/jenkins.io.key',
       },
     }
   }
   else {
     apt::source { 'jenkins':
-      location => 'http://pkg.jenkins-ci.org/debian',
+      location => 'http://pkg.jenkins.io/debian',
       release  => 'binary/',
       repos    => '',
       include  => {
@@ -33,7 +33,7 @@ class jenkins::repo::debian
       },
       key      => {
         'id'     => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-        'source' => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+        'source' => 'http://pkg.jenkins.io/debian/jenkins.io.key',
       },
     }
   }

--- a/manifests/repo/el.pp
+++ b/manifests/repo/el.pp
@@ -12,9 +12,9 @@ class jenkins::repo::el
   if $::jenkins::lts  {
     yumrepo {'jenkins':
       descr    => 'Jenkins',
-      baseurl  => 'http://pkg.jenkins-ci.org/redhat-stable/',
+      baseurl  => 'http://pkg.jenkins.io/redhat-stable/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
+      gpgkey   => 'http://pkg.jenkins.io/redhat/jenkins.io.key',
       enabled  => 1,
       proxy    => $repo_proxy,
     }
@@ -23,9 +23,9 @@ class jenkins::repo::el
   else {
     yumrepo {'jenkins':
       descr    => 'Jenkins',
-      baseurl  => 'http://pkg.jenkins-ci.org/redhat/',
+      baseurl  => 'http://pkg.jenkins.io/redhat/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
+      gpgkey   => 'http://pkg.jenkins.io/redhat/jenkins.io.key',
       enabled  => 1,
       proxy    => $repo_proxy,
     }

--- a/manifests/repo/suse.pp
+++ b/manifests/repo/suse.pp
@@ -10,16 +10,16 @@ class jenkins::repo::suse
   if $::jenkins::lts {
     zypprepo {'jenkins':
       descr    => 'Jenkins',
-      baseurl  => 'http://pkg.jenkins-ci.org/opensuse-stable/',
+      baseurl  => 'http://pkg.jenkins.io/opensuse-stable/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
+      gpgkey   => 'http://pkg.jenkins.io/redhat/jenkins.io.key',
     }
   } else {
     zypprepo {'jenkins':
       descr    => 'Jenkins',
-      baseurl  => 'http://pkg.jenkins-ci.org/opensuse/',
+      baseurl  => 'http://pkg.jenkins.io/opensuse/',
       gpgcheck => 1,
-      gpgkey   => 'http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key',
+      gpgkey   => 'http://pkg.jenkins.io/redhat/jenkins.io.key',
     }
   }
 }


### PR DESCRIPTION
* replace deprecated pkg.jenkins-ci.org with pkg.jenkins.io in jenkins::repo:: classes - fixes issue described in #678 