### PR TITLE
Fix '-remoting' flag tests

### DIFF
--- a/spec/classes/jenkins_cli_spec.rb
+++ b/spec/classes/jenkins_cli_spec.rb
@@ -25,7 +25,7 @@ describe 'jenkins', :type => :class do
       it { should contain_class('jenkins::cli') }
       it { should contain_exec('jenkins-cli') }
       it { should contain_exec('reload-jenkins').with_command(/http:\/\/localhost:9000/) }
-      it { should contain_exec('reload-jenkins').with_command(/-i\s\/path\/to\/key/) }
+      it { should contain_exec('reload-jenkins').with_command(/-remoting -i\s\/path\/to\/key/) }
       it { should contain_exec('safe-restart-jenkins') }
       it { should contain_jenkins__sysconfig('HTTP_PORT').with_value('9000') }
 

--- a/spec/unit/puppet_x/jenkins/provider/cli_spec.rb
+++ b/spec/unit/puppet_x/jenkins/provider/cli_spec.rb
@@ -489,7 +489,7 @@ describe PuppetX::Jenkins::Provider::Cli do
                 'java',
                 '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
                 '-s', 'http://localhost:8080',
-                '-i', 'cat.id_rsa',
+                '-remoting -i', 'cat.id_rsa',
                 'foo'
               ],
               { :failonfail => true, :combine => true }
@@ -513,7 +513,7 @@ describe PuppetX::Jenkins::Provider::Cli do
                 'java',
                 '-jar', '/usr/lib/jenkins/jenkins-cli.jar',
                 '-s', 'http://localhost:8080',
-                '-i', 'cat.id_rsa',
+                '-remoting -i', 'cat.id_rsa',
                 'foo'
               ],
               { :failonfail => true, :combine => true }


### PR DESCRIPTION
In Jenkins 2.54, there was safer remoting enabled. In the process of this, the `-remoting` flag was added as part of CLI options. This is reflected in: https://github.com/jenkinsci/puppet-jenkins/pull/751. However, the relevant tests weren’t changed to reflect this.

This PR is a fix for that. 