### PR TITLE
Add support for -auth switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ by passing the keyfile path as a class parameter:
 
     jenkins::cli_ssh_keyfile: "/path/to/id_rsa"
 
+You can also configure `jenkins::cli_helper` to use a jenkins user and API token:
+
+```puppet
+  class {'jenkins':
+    cli_auth => "${jenkins_user}:${api_token}",
+  }
+```
+
+`cli_ssh_keyfile` and `cli_auth` are mutually exclusive, ie. they can not both be specified.
+
 __Direct including of the `jenkins::cli_helper` class into the manifest is deprecated.__
 
 There's an open bug in Jenkins (JENKINS-22346) that causes authentication to

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -54,6 +54,8 @@ class jenkins::cli {
     $auth_arg = "-remoting -i ${::jenkins::cli_ssh_keyfile}"
   } elsif $::jenkins::cli_auth {
     $auth_arg = "-auth ${::jenkins::cli_auth}"
+  } else {
+    $auth_arg = undef
   }
 
   # The jenkins cli command with required parameter(s)

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -46,11 +46,14 @@ class jenkins::cli {
   $port = jenkins_port()
   $prefix = jenkins_prefix()
 
-  # Provide the -i flag if specified by the user.
+  # set authentication option
+  if $::jenkins::cli_ssh_keyfile and $::jenkins::cli_auth {
+    fail('Must specify only one of cli_ssh_keyfile and cli_auth')
+  }
   if $::jenkins::cli_ssh_keyfile {
     $auth_arg = "-remoting -i ${::jenkins::cli_ssh_keyfile}"
-  } else {
-    $auth_arg = undef
+  } elsif $::jenkins::cli_auth {
+    $auth_arg = "-auth ${::jenkins::cli_auth}"
   }
 
   # The jenkins cli command with required parameter(s)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -179,6 +179,11 @@
 #   Provides the location of an ssh private key file to make authenticated
 #   connections to the Jenkins CLI.
 #
+# @param cli_auth
+#   Specify a username and token to be passed to the -auth parameter
+#
+#   eg. cli_auth => join([$username,$api_token], ':')
+#
 # @param cli_tries
 #   Retries until giving up talking to jenkins API
 #
@@ -295,6 +300,7 @@ class jenkins(
   $no_proxy_list        = undef,
   $cli                  = true,
   $cli_ssh_keyfile      = undef,
+  $cli_auth             = undef,
   $cli_tries            = $jenkins::params::cli_tries,
   $cli_try_sleep        = $jenkins::params::cli_try_sleep,
   $port                 = $jenkins::params::port,
@@ -336,6 +342,7 @@ class jenkins(
   if $no_proxy_list { validate_array($no_proxy_list) }
   validate_bool($cli)
   if $cli_ssh_keyfile { validate_absolute_path($cli_ssh_keyfile) }
+  if $cli_auth { validate_string($cli_auth) }
   validate_integer($cli_tries)
   validate_integer($cli_try_sleep)
   validate_integer($port)


### PR DESCRIPTION
The change allows the user to provide a user and auth token which is passed to the `-auth` switch to jenkins-cli.