### PR TITLE
Support null passphrase when fetching credential_info

### DIFF
--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -456,7 +456,7 @@ class Actions {
     current_credentials['password'] = credentials.password.plainText
     } else {
       current_credentials['private_key'] = credentials.privateKey
-      current_credentials['passphrase'] = credentials.passphrase.plainText
+      current_credentials['passphrase'] = credentials.passphrase?.plainText
     }
 
     def builder = new groovy.json.JsonBuilder(current_credentials)


### PR DESCRIPTION
This is the same fix as in https://github.com/jenkinsci/puppet-jenkins/commit/fcf3da8ce9e95c3b9ca48beb0a4adb3a00a0e4b6 but applied in another place in the file that assumed passphrase couldn't be null. (I checked, couldn't see anywhere else that would also need the same thing.)