### PR TITLE
bump stdlib min version to 4.18.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       ref: "2.1.0"
     stdlib:
       repo: "https://github.com/puppetlabs/puppetlabs-stdlib"
-      ref: "4.6.0"
+      ref: "4.18.0"
     java: "https://github.com/puppetlabs/puppetlabs-java"
     zypprepo: "https://github.com/deadpoint/puppet-zypprepo.git"
     archive: "https://github.com/voxpupuli/puppet-archive.git"

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0 < 5.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.18.0 < 5.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 2.1.0 < 3.0.0" },
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 2.0.0" },
     { "name": "darin/zypprepo", "version_requirement": ">= 1.0.1 < 2.0.0" },


### PR DESCRIPTION
Resolves multiple instances of this error message when executing spec
tests with under ruby 2.4 / puppet 4.10.6:

    Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Resource type not found: Stdlib::Absolutepath