### PR TITLE
Reimplementing #467

### DIFF
--- a/NATIVE_TYPES_AND_PROVIDERS.md
+++ b/NATIVE_TYPES_AND_PROVIDERS.md
@@ -274,6 +274,7 @@ jenkins_credentials { '<id>':
 
 * `UsernamePasswordCredentialsImpl`
 * `BasicSSHUserPrivateKey`
+* `StringCredentialsImpl`
 * `FileCredentialsImpl`
 * `ConduitCredentialsImpl`
 
@@ -309,7 +310,7 @@ jenkins_credentials { 'a0469025-1202-4007-983d-0c62f230f1a7':
 }
 ```
 
-#### `FileCredentialsImpl`
+#### `StringCredentialsImpl`
 
 Using this credential type requires that the jenkins `plain-credentials` plugin
 has been installed.
@@ -322,6 +323,23 @@ jenkins_credentials { '150b2895-b0eb-4813-b8a5-3779690c063c':
   impl        => 'StringCredentialsImpl',
   scope       => 'SYSTEM',
   secret      => '42',
+}
+```
+
+#### `FileCredentialsImpl`
+
+Using this credential type requires that the jenkins `plain-credentials` plugin
+has been installed.
+
+```
+jenkins_credentials { '95bfe159-8bf0-4605-be20-47e201220e7c':
+  ensure      => 'present',
+  description => 'secret file with very secret data',
+  domain      => undef,
+  impl        => 'FileCredentialsImpl',
+  scope       => 'GLOBAL',
+  file_name   => 'foo.bar',
+  content     => 'secret data on 1st line\nsecret data on 2nd line'
 }
 ```
 

--- a/files/puppet_helper.groovy
+++ b/files/puppet_helper.groovy
@@ -609,6 +609,17 @@ class Actions {
           new Secret(conf['secret'])
         )
         break
+      case 'FileCredentialsImpl':
+        util.requirePlugin('plain-credentials')
+
+        cred = this.class.classLoader.loadClass('org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl').newInstance(
+          CredentialsScope."${conf['scope']}",
+          conf['id'],
+          conf['description'],
+          conf['file_name'],
+          SecretBytes.fromBytes(conf['content'].getBytes())
+        )
+        break
       default:
         throw new UnsupportedCredentialsClass("unsupported " + conf['impl'])
     }

--- a/lib/puppet/type/jenkins_credentials.rb
+++ b/lib/puppet/type/jenkins_credentials.rb
@@ -34,8 +34,7 @@ Puppet::X::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
               :BasicSSHUserPrivateKey,
               :ConduitCredentialsImpl,
               :StringCredentialsImpl,
-              :FileCredentialsImpl
-            )
+              :FileCredentialsImpl)
   end
 
   newproperty(:description) do

--- a/lib/puppet/type/jenkins_credentials.rb
+++ b/lib/puppet/type/jenkins_credentials.rb
@@ -33,7 +33,9 @@ Puppet::X::Jenkins::Type::Cli.newtype(:jenkins_credentials) do
     newvalues(:UsernamePasswordCredentialsImpl,
               :BasicSSHUserPrivateKey,
               :ConduitCredentialsImpl,
-              :StringCredentialsImpl)
+              :StringCredentialsImpl,
+              :FileCredentialsImpl
+            )
   end
 
   newproperty(:description) do

--- a/spec/acceptance/xtypes/jenkins_credentials_spec.rb
+++ b/spec/acceptance/xtypes/jenkins_credentials_spec.rb
@@ -113,6 +113,35 @@ describe 'jenkins_credentials' do
           it { should contain '<id>150b2895-b0eb-4813-b8a5-3779690c063c</id>' }
         end
       end
+
+      context 'FileCredentialsImpl' do
+        it 'should work with no errors' do
+          pp = base_manifest + <<-EOS
+            jenkins::plugin { 'plain-credentials':
+              pin => true,
+            }
+
+            jenkins_credentials { '95bfe159-8bf0-4605-be20-47e201220e7c':
+              ensure      => 'present',
+              description => 'secret file with very secret data',
+              domain      => undef,
+              impl        => 'FileCredentialsImpl',
+              scope       => 'GLOBAL',
+              file_name   => 'foo.bar',
+              content     => 'secret data on 1st line\nsecret data on 2nd line'
+            }
+          EOS
+
+          apply2(pp)
+        end
+
+        describe file('/var/lib/jenkins/credentials.xml') do
+          # XXX need to properly compare the XML doc
+          # trying to match anything other than the id this way might match other
+          # credentails
+          it { should contain '<id>95bfe159-8bf0-4605-be20-47e201220e7c</id>' }
+        end
+      end
     end # 'present' do
 
     context 'absent' do
@@ -139,6 +168,35 @@ describe 'jenkins_credentials' do
           # trying to match anything other than the id this way might match other
           # credentails
           it { should_not contain '<id>150b2895-b0eb-4813-b8a5-3779690c063c</id>' }
+        end
+      end
+
+      context 'FileCredentialsImpl' do
+        it 'should work with no errors' do
+          pp = base_manifest + <<-EOS
+            jenkins::plugin { 'plain-credentials':
+              pin => true,
+            }
+
+            jenkins_credentials { '95bfe159-8bf0-4605-be20-47e201220e7c':
+              ensure      => 'absent',
+              description => 'secret file with very secret data',
+              domain      => undef,
+              impl        => 'FileCredentialsImpl',
+              scope       => 'GLOBAL',
+              file_name   => 'foo.bar',
+              content     => 'secret data on 1st line\nsecret data on 2nd line'
+            }
+          EOS
+
+          apply2(pp)
+        end
+
+        describe file('/var/lib/jenkins/credentials.xml') do
+          # XXX need to properly compare the XML doc
+          # trying to match anything other than the id this way might match other
+          # credentails
+          it { should_not contain '<id>95bfe159-8bf0-4605-be20-47e201220e7</id>' }
         end
       end
     end # 'absent' do

--- a/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
@@ -142,7 +142,7 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
     end
   end
 
-  shared_examples "a provider from example hash 4" do
+  shared_examples 'a provider from example hash 4' do
     it do
       cred = credentials[3]
 

--- a/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
+++ b/spec/unit/puppet/provider/jenkins_credentials/cli_spec.rb
@@ -33,6 +33,15 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
             "impl": "StringCredentialsImpl",
             "description": "baz",
             "secret": "fluffy bunny"
+        },
+        {
+            "id": "08f8006e-371d-4daa-961b-f6e616f7a061",
+            "domain": null,
+            "scope": "GLOBAL",
+            "impl": "FileCredentialsImpl",
+            "description": "baz",
+            "file_name": "baz.file",
+            "content": "asdf"
         }
     ]
     EOS
@@ -130,7 +139,37 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
       ].each do |k|
         expect(provider.public_send(k.to_sym)).to eq :absent
       end
+    end
+  end
 
+  shared_examples "a provider from example hash 4" do
+    it do
+      cred = credentials[3]
+
+      expect(provider.name).to eq cred['id']
+      expect(provider.ensure).to eq :present
+      [
+        'domain',
+        'scope',
+        'impl',
+        'description',
+        'secret',
+        'file_name',
+        'content',
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq cred[k].nil? ? :undef : cred[k]
+      end
+
+      [
+        'username',
+        'password',
+        'private_key',
+        'passphrase',
+        'source',
+        'key_store_impl'
+      ].each do |k|
+        expect(provider.public_send(k.to_sym)).to eq :absent
+      end
     end
   end
 
@@ -144,7 +183,7 @@ describe Puppet::Type.type(:jenkins_credentials).provider(:cli) do
       end
 
       it 'should return the correct number of instances' do
-        expect(described_class.instances.size).to eq 3
+        expect(described_class.instances.size).to eq 4
       end
 
       context 'first instance returned' do

--- a/spec/unit/puppet/type/jenkins_credentials_spec.rb
+++ b/spec/unit/puppet/type/jenkins_credentials_spec.rb
@@ -30,6 +30,7 @@ describe Puppet::Type.type(:jenkins_credentials) do
           :UsernamePasswordCredentialsImpl,
           :BasicSSHUserPrivateKey,
           :StringCredentialsImpl,
+          :FileCredentialsImpl
         ]
     end
 


### PR DESCRIPTION
This PR reimplements the functionality introduced by @matez's work in #467 

This implements the `FileCredentialsImpl` credential type for `jenkins_credentials`.