### PR TITLE
Fix for unhandled error message received from the jenkins-cli.jar

### DIFF
--- a/lib/puppet/x/jenkins/provider/cli.rb
+++ b/lib/puppet/x/jenkins/provider/cli.rb
@@ -278,6 +278,7 @@ class Puppet::X::Jenkins::Provider::Cli < Puppet::Provider
                         'You must authenticate to access this Jenkins.',
                         'anonymous is missing the Overall/Read permission',
                         'anonymous is missing the Overall/RunScripts permission',
+                        'java.io.IOException: Server returned HTTP response code: 503 for URL',
                       ]
     # network errors / jenkins not ready for connections not related to
     # authenication failures


### PR DESCRIPTION
Hi Jenkins Puppet people, 

I was having a very difficult time getting the native types/providers working. I ended up reading the code and throwing in some extra debugging. I found that the exception handling code wasn't picking up the "ERROR: anonymous is missing the Overall/RunScripts permission" message (which is the message I was getting if I ran the command manually as the Jenkins user, I don't know why this wasn't being passed back to the ruby code). I printed out the exception, and got the error as below: 

```
Debug: Jenkins_user::ProviderCli cli_auth_required: false
Debug: Executing: '/bin/cat /usr/lib/jenkins/puppet_helper.groovy | /bin/java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 groovy = user_info_all'
Warning: Got an error executing, the message is Execution of '/bin/cat /usr/lib/jenkins/puppet_helper.groovy | /bin/java -jar /usr/lib/jenkins/jenkins-cli.jar -s http://localhost:8080 groovy = user_info_all' returned 255: 
java.io.IOException: Server returned HTTP response code: 503 for URL: http://localhost:8080/cli?remoting=false
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1840)
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1441)
        at hudson.cli.FullDuplexHttpStream.<init>(FullDuplexHttpStream.java:99)
        at hudson.cli.CLI.plainHttpConnection(CLI.java:652)
        at hudson.cli.CLI._main(CLI.java:612)
        at hudson.cli.CLI.main(CLI.java:426)
```

To fix it, I added the extra line as seen in the pull request code. 

Cheers, 
Nick