### PR TITLE
Add missing dependency to the gitlab plugin (credentials) test

### DIFF
--- a/spec/acceptance/xtypes/jenkins_credentials_spec.rb
+++ b/spec/acceptance/xtypes/jenkins_credentials_spec.rb
@@ -184,6 +184,7 @@ describe 'jenkins_credentials' do
               'matrix-project',
               'junit',
               'script-security',
+              'workflow-api',
               'workflow-step-api',
               'workflow-scm-step',
               'git',


### PR DESCRIPTION
Looks like it might be a dependency issue since gitlab-plugin depends on new versions of everything.