### PR TITLE
bump dependency on camptocamp/systemd

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -24,7 +24,7 @@
     { "name": "puppetlabs/java", "version_requirement": ">= 1.0.1 < 3.0.0" },
     { "name": "puppet/zypprepo", "version_requirement": ">= 2.0.0 < 3.0.0" },
     { "name": "puppet/archive", "version_requirement": ">= 1.3.0 < 3.0.0" },
-    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 1.0.0" },
+    { "name": "camptocamp/systemd", "version_requirement": ">= 0.3.0 < 2.0.0" },
     { "name": "puppetlabs/transition", "version_requirement": ">= 0.1.0 < 1.0.0" }
   ]
 }


### PR DESCRIPTION
Just a small dependency bump. Can't find any changes in the systemd 1.* series that might conflict with the use in this module.